### PR TITLE
fix uninitialize constant error

### DIFF
--- a/lib/tasks/genova.thor
+++ b/lib/tasks/genova.thor
@@ -171,7 +171,7 @@ module GenovaCli
       code_manager.pull
 
       path = code_manager.task_definition_config_path(options[:path])
-      task = EcsDeployer::Task::Client.new.register(path, tag: 'latest')
+      task = Genova::Ecs::Task::Client.new.register(path, tag: 'latest')
 
       puts("Registered task. [#{task.task_definition_arn}]")
     end


### PR DESCRIPTION
# 概要

https://github.com/metaps/genova/wiki/Task-configuration
実行時にエラーが出ました。

```
$ docker-compose run --rm rails thor genova:register-task -r {REPOSITORY} --path config/deploy/staging.yml
Starting genova-mongo ... done
Starting genova-redis ... done
Traceback (most recent call last):
	13: from /usr/local/bundle/bin/thor:23:in `<main>'
	12: from /usr/local/bundle/bin/thor:23:in `load'
	11: from /usr/local/bundle/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'
module GenovaCli
  class Deploy < Thor
    class_option :account, default: ENV.fetch('GITHUB_ACCOUNT', Settings.github.account), desc: 'GitHub account name'
    class_option :branch, default: Settings.github.default_branch, aliases: :b, desc: 'Branch name.'
    class_option :force, default: false, type: :boolean, aliases: :f, desc: 'Ignore deploy lock and force deploy.'
    class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Prompt before exectuion.'
    class_option :ssh_secret_key_path, desc: 'Private key for retrieving repository.'
    class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Output verbose log.'

    no_commands do
      def deploy(options)
        return if options[:interactive] && !HighLine.new.agree('> Do you want to deploy? (y/n): ', '')

        code_manager = ::Genova::CodeManager::Git.new(options[:account], options[:repository], options[:branch]) if options[:repository].present?

        options.merge!(code_manager.load_deploy_config.target(options[:target])) if options[:target].present?
        base_path = nil

        Settings.github.repositories.each do |repository|
          next unless repository[:alias] == options[:repository]

          options[:repository] = repository[:name]
          base_path = repository[:base_path]
          break
        end

        deploy_job = DeployJob.new(
          mode: DeployJob.mode.find_value(:manual).to_sym,
          type: options[:type],
          account: options[:account],
          branch: options[:branch],
          cluster: options[:cluster],
          base_path: base_path,
          service: options[:service],
          scheduled_task_rule: options[:scheduled_task_rule],
          scheduled_task_target: options[:scheduled_task_target],
          repository: options[:repository],
          ssh_secret_key_path: options[:ssh_secret_key_path],
          run_task: options[:run_task]
        )

        extra = {
          interactive: options[:interactive],
          verbose: options[:verbose],
          force: options[:force]
        }

        ::Genova::Client.new(deploy_job, extra).run
      end
    end

    desc 'run-task', 'Deploy run task to ECS'
    option :cluster, required: true, aliases: :c, desc: 'Cluster name.'
    option :run_task, aliases: :t, desc: 'Task name.'
    option :repository, required: true, aliases: :r, desc: 'Repository name.'
    option :target, aliases: :t, desc: 'Deploy by specifying target.'
...skipping...
	10: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'

▽
115       payload_body = Oj.dump(post_data)
	 9: from /usr/local/bundle/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	 8: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	 7: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'
	 6: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'
	 5: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'
	 4: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	 3: from /usr/local/bundle/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	 2: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	 1: from /usr/local/bundle/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
/app/lib/tasks/genova.thor:160:in `register_task': uninitialized constant Thor::Sandbox::GenovaCli::Default::EcsDeployer (NameError)
```

# 修正
* 定数の修正