### PR TITLE
[#120] alias 使用時の CLI Deploy エラー解消

### DIFF
--- a/lib/tasks/genova.thor
+++ b/lib/tasks/genova.thor
@@ -26,7 +26,7 @@ module GenovaCli
           service: options[:service],
           scheduled_task_rule: options[:scheduled_task_rule],
           scheduled_task_target: options[:scheduled_task_target],
-          repository: options[:repository],
+          repository: repository[:name],
           ssh_secret_key_path: options[:ssh_secret_key_path],
           run_task: options[:run_task]
         )


### PR DESCRIPTION
[settings_helper](https://github.com/metaps/genova/blob/develop/lib/genova/config/settings_helper.rb#L18) で取得した `settings.local.yml` の name を使用するように変更
