### PR TITLE
CodeManagerのInitializerへの引数を修正

### DIFF
--- a/lib/genova/slack/bot.rb
+++ b/lib/genova/slack/bot.rb
@@ -476,7 +476,7 @@ module Genova
         task_definitions = task_definition.task_definition.container_definitions
 
         deployed_commit_id = nil
-        code_manager = Genova::CodeManager::Git.new(params[:account], params[:repository], params)
+        code_manager = Genova::CodeManager::Git.new(params[:account], params[:repository])
 
         task_definitions.each do |task|
           matches = task[:image].match(/(build\-.*$)/)

--- a/lib/genova/slack/bot.rb
+++ b/lib/genova/slack/bot.rb
@@ -476,7 +476,7 @@ module Genova
         task_definitions = task_definition.task_definition.container_definitions
 
         deployed_commit_id = nil
-        code_manager = Genova::CodeManager::Git.new(params[:account], branch: params[:repository])
+        code_manager = Genova::CodeManager::Git.new(params[:account], params[:repository], params)
 
         task_definitions.each do |task|
           matches = task[:image].match(/(build\-.*$)/)


### PR DESCRIPTION
# 概要
slack deploy時に以下のエラーが発生
`no implicit conversion of Symbol into Integer`

<img width="605" alt="スクリーンショット 2020-04-01 9 40 55" src="https://user-images.githubusercontent.com/30610744/78087726-fa820800-73fc-11ea-99ad-c51afef53e4c.png">

引数の渡し方を修正しました。