### PR TITLE
Feature/oauth v2

### DIFF
--- a/app/workers/slack/command_worker.rb
+++ b/app/workers/slack/command_worker.rb
@@ -28,6 +28,8 @@ module Slack
       end
 
       klass = "Genova::Slack::Command::#{statements[:command].capitalize}"
+      raise Genova::Exceptions::InvalidArgumentError, "#{commands[0]} command does not exist." if klass.safe_constantize.nil?
+
       client = Genova::Slack::Bot.new
 
       Object.const_get(klass).call(client, statements, queue.user)


### PR DESCRIPTION
#131

https://github.com/slack-ruby/slack-ruby-bot
> Warning: As of December 4th, 2020 Slack no longer accept resubmissions from apps that are not using granular permissions, or so-called "classic apps". On November 18, 2021 Slack will start delisting apps that have not migrated to use granular permissions. This library implements legacy, real-time support for classic apps. You should not be building a new bot with it and use slack-ruby-bot-server-events instead. For a rudimentary bot you can even start with slack-ruby-bot-server-events-app-mentions. See MIGRATION for migration help.

classicアプリが年内で廃止されるため、genovaをOAuth 2.0に対応させました。
破壊的な変更が入るため、genova 3.0としてリリース予定です。

https://github.com/metaps/genova/wiki/Slack-interactive-deploy

アップデート後は全てのログが標準出力に吐かれるようになるため、 `logs` ディレクトリ下は `.keep` を残して全て削除してください。