### PR TITLE
Add depends_on for all image that require base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     depends_on:
       - mongo
       - redis
+      - base
     restart: ${DOCKER_RESTART}
   slack:
     build:
@@ -38,6 +39,7 @@ services:
     depends_on:
       - mongo
       - redis
+      - base
     restart: on-failure
   sidekiq:
     build:
@@ -52,6 +54,7 @@ services:
     depends_on:
       - mongo
       - redis
+      - base
     restart: ${DOCKER_RESTART}
   cron:
     build:
@@ -63,6 +66,8 @@ services:
       - .:/app:cached
       - /var/run/docker.sock:/var/run/docker.sock
     restart: ${DOCKER_RESTART}
+    depends_on:
+      - base
   node:
     build:
       context: .


### PR DESCRIPTION
What
`docker-compose build` fail on following docker-compose version due to build sequence
```
docker-compose version 1.23.2, build 1110ad0
docker-py version: 3.6.0
CPython version: 2.7.12
```

Error
```
Building cron
Step 1/3 : FROM base
Service 'cron' failed to build: pull access denied for base, repository does not exist or may require 'docker login'
```

Reference : https://stackoverflow.com/questions/46295806/how-to-control-docker-compose-build-order