### PR TITLE
Raise exception for all case

### DIFF
--- a/lib/genova/run.rb
+++ b/lib/genova/run.rb
@@ -61,7 +61,7 @@ module Genova
       logger.error(e.backtrace.join("\n")) if e.backtrace.present?
 
       cancel(transaction, deploy_job)
-      raise e unless deploy_job.mode == DeployJob.mode.find_value(:manual)
+      raise e
     end
 
     class << self


### PR DESCRIPTION
When deployment failed we should expect the return for CLI as non 0

Is there reason why we are not raising the error when it is manual?