### PR TITLE
Remove chdir

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,12 @@ gem 'config'
 gem 'deep_merge', require: 'deep_merge/rails_compat'
 gem 'docker-api'
 gem 'enumerize'
-gem 'git'
+
+# When using git with Sidekiq, errors may occur because it is not thread safe.
+# Until the issue is fixed, the policy is to use the thread-safe fork version.
+# https://github.com/metaps/genova/issues/369
+gem 'git', git: 'https://github.com/fxposter/ruby-git', branch: 'remove-chdir'
+
 gem 'grape'
 gem 'grape_logging'
 gem 'hash_validator'
@@ -45,8 +50,6 @@ gem 'tzinfo-data'
 gem 'vite_rails'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
   gem 'rspec-rails'
   gem 'simplecov', '~> 0.17.1'
 end
@@ -54,6 +57,7 @@ end
 group :test do
   # http://qiita.com/Anorlondo448/items/95946ebb071a4c3500fb
   gem 'rspec-sidekiq'
+
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/fxposter/ruby-git
+  revision: 37f92a1bded5a295692799b06889e70494ed79cb
+  branch: remove-chdir
+  specs:
+    git (1.18.0)
+      addressable (~> 2.8)
+      rchardet (~> 1.8)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,7 +75,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.4)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     async (2.5.1)
@@ -108,7 +117,6 @@ GEM
     brakeman (6.0.0)
     bson (4.15.0)
     builder (3.2.4)
-    byebug (11.1.3)
     concurrent-ruby (1.2.2)
     config (4.2.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -179,9 +187,6 @@ GEM
     ffi (1.15.5)
     fiber-local (1.0.0)
     foreman (0.87.2)
-    git (1.18.0)
-      addressable (~> 2.8)
-      rchardet (~> 1.8)
     gli (2.21.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -287,7 +292,7 @@ GEM
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
-    public_suffix (5.0.1)
+    public_suffix (5.0.4)
     puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.0)
@@ -489,12 +494,11 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   brakeman
-  byebug
   config
   deep_merge
   docker-api
   enumerize
-  git
+  git!
   grape
   grape_logging
   hash_validator

--- a/lib/autoloads/genova/deploy/transaction.rb
+++ b/lib/autoloads/genova/deploy/transaction.rb
@@ -4,7 +4,7 @@ module Genova
       LOCK_WAIT_INTERVAL = 20
 
       def initialize(repository, options = {})
-        @key = "trans_#{Settings.github.account}"
+        @key = "trans_#{Settings.github.account}:#{repository}"
         @repository = repository
         @logger = options[:logger] || ::Logger.new($stdout, level: Settings.logger.level)
         @force = options[:force]


### PR DESCRIPTION
Because the Git gem is not thread-safe, a Git error may occur when calling from Sidekiq.
To avoid this problem, we will use the thread-safe Fork version.