### PR TITLE
Support build encrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'aws-sdk-ecs'
 gem 'aws-sdk-eventbridge'
 gem 'aws-sdk-iam'
 gem 'aws-sdk-kms'
+gem 'aws-sdk-secretsmanager'
+gem 'aws-sdk-ssm'
 gem 'bootsnap', require: false
 gem 'config', '~> 5.1.0'
 gem 'deep_merge', require: 'deep_merge/rails_compat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,12 @@ GEM
     aws-sdk-kms (1.64.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-secretsmanager (1.75.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-ssm (1.150.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
@@ -522,6 +528,8 @@ DEPENDENCIES
   aws-sdk-eventbridge
   aws-sdk-iam
   aws-sdk-kms
+  aws-sdk-secretsmanager
+  aws-sdk-ssm
   better_errors
   binding_of_caller
   bootsnap

--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -26,6 +26,16 @@
                       }
                     }
                   },
+                  "secret_args": {
+                    "type": "object",
+                    "patternProperties": {
+                      ".+": {
+                        "oneOf": [
+                          { "type": "string" }
+                        ]
+                      }
+                    }
+                  },
                   "target": { "type": "string" }
                 }
               }

--- a/lib/autoloads/genova/docker/client.rb
+++ b/lib/autoloads/genova/docker/client.rb
@@ -103,7 +103,7 @@ module Genova
               raw_value = ssm.get_parameter(name: value, with_decryption: true).parameter.value
             end
 
-            result[:build_args_string] += " --buid-arg #{key}='#{raw_value}'"
+            result[:build_args_string] += " --build-arg #{key}='#{raw_value}'"
             result[:build_args_filtered_string] += " --build-arg #{key}='{FILTERD}'"
           end
         end

--- a/lib/autoloads/genova/docker/client.rb
+++ b/lib/autoloads/genova/docker/client.rb
@@ -93,6 +93,21 @@ module Genova
           end
         end
 
+        if build[:secret_args].is_a?(Hash)
+          build[:secret_args].each do |key, value|
+            if value.start_with?('arn:aws:secretsmanager:')
+              secrets_manager = Aws::SecretsManager::Client.new
+              raw_value = secrets_manager.get_secret_value(secret_id: value).secret_string
+            else
+              ssm = Aws::SSM::Client.new
+              raw_value = ssm.get_parameter(name: value, with_decryption: true).parameter.value
+            end
+
+            result[:build_args_string] += " --buid-arg #{key}='#{raw_value}'"
+            result[:build_args_filtered_string] += " --build-arg #{key}='{FILTERD}'"
+          end
+        end
+
         result
       end
 

--- a/spec/lib/autoloads/genova/docker/client_spec.rb
+++ b/spec/lib/autoloads/genova/docker/client_spec.rb
@@ -19,24 +19,27 @@ module Genova
         end
 
         context 'when build is string' do
-          container_config = {
-            name: 'web',
-            build: '.'
+          let(:container_config) {
+            {
+              name: 'web',
+              build: '.'
+            }
           }
 
           it 'should return docker build time' do
             expect(docker_client.build_image(container_config, 'web')).to eq(0.0)
           end
 
-          it 'should return docker build time when --no-cache is specified' do
+          it 'should return valid command' do
             docker_client.no_cache = true
             docker_client.build_image(container_config, 'web')
 
             expect(Genova::Command::Executor).to have_received(:call) do |command, _, _|
-              base_pattern = 'docker build -t web:latest -f /app/config/Dockerfile --label com.metaps.genova.build_key='
-              key_pattern = '\\w{8}'
-              tail_pattern = ' --no-cache /app/config'
-              pattern = Regexp.new(Regexp.escape(base_pattern) + key_pattern + Regexp.escape(tail_pattern))
+              pattern = 'docker build ' +
+                '-t web:latest ' +
+                "-f #{Rails.root}/config/Dockerfile " +
+                '--label com.metaps.genova.build_key=\\w{8} ' +
+                "--no-cache #{Rails.root}/config"
 
               expect(command).to match(pattern)
             end
@@ -44,22 +47,60 @@ module Genova
         end
 
         context 'when build is hash' do
-          it 'should return repository name' do
-            container_config = {
-              name: 'web',
-              build: {
-                context: '.',
-                args: {
-                  FOO: 'foo',
-                  BAR: 'bar'
+          context 'when args is specified' do
+            let(:container_config) {
+              {
+                name: 'web',
+                build: {
+                  context: '.',
+                  args: {
+                    FOO: 'foo',
+                    BAR: 'bar'
+                  }
                 }
               }
             }
 
-            allow(cipher).to receive(:encrypt_format?).and_return(true, false)
-            allow(cipher).to receive(:decrypt).and_return('foo', 'bar')
+            it 'should return docker build time' do
+              allow(cipher).to receive(:encrypt_format?).and_return(true, false)
+              allow(cipher).to receive(:decrypt).and_return('foo', 'bar')
 
-            expect(docker_client.build_image(container_config, 'account_id.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest')).to eq(0.0)
+              expect(docker_client.build_image(container_config, 'account_id.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest')).to eq(0.0)
+            end
+          end
+
+          context 'when secret_args is specified' do
+            let(:container_config) {
+              {
+                name: 'web',
+                build: {
+                  context: '.',
+                  secret_args: {
+                    # Secrets Manager
+                    FOO: 'arn:aws:secretsmanager:ap-northeast-1:000000000000:secret:baz',
+
+                    # Parameter Store
+                    BAR: 'arn:aws:ssm:ap-northeast-1:000000000000:secret:QUZ',
+                    BAZ: 'quux'
+                  }
+                }
+              }
+            }
+
+            it 'should return valid command' do
+              docker_client.build_image(container_config, 'web')
+
+              expect(Genova::Command::Executor).to have_received(:call) do |command, _, _|
+                pattern = 'docker build ' +
+                    '-t web:latest ' +
+                    "-f #{Rails.root}/config/Dockerfile " +
+                    '--label com.metaps.genova.build_key=\\w{8} ' +
+                    "--build-arg FOO='SecretStringType' --build-arg BAR='PSParameterValue' --build-arg BAZ='PSParameterValue' "
+                    "#{Rails.root}/config"
+
+                expect(command).to match(pattern)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
`deploy.yml` でParrameter Store、またはSecrets Managerから値を参照できるようにしました。

```yml
clusters:
  - name: xxx
    services:
      xxx:
        containers:
          - name: xxx
            build:
              secret_args:
                # Retrieve from Secrets Manager
                FOO: {ARN}

                # Retrieve from Parameter Store
                FOO: {ARN or Name}
```

* [Retrieve Secrets Manager secrets through Amazon ECS environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html)
* [Retrieve Systems Manager parameters through Amazon ECS environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-ssm-paramstore.html)