### PR TITLE
Moving environment definitions to external files

### DIFF
--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -90,10 +90,17 @@ module Genova
 
         def load_environment_from_files!(task_definition, task_definition_path)
           raise Exceptions::TaskDefinitionValidationError, '\'container_definitions\' is undefined.' unless task_definition.key?(:container_definitions)
+          unless task_definition[:container_definitions].is_a?(Array)
+            raise Exceptions::TaskDefinitionValidationError, '\'container_definitions\' must be an array.'
+          end
 
           base_dir = Pathname(task_definition_path).dirname
 
           task_definition[:container_definitions].each do |container_definition|
+            unless container_definition.is_a?(Hash)
+              raise Exceptions::TaskDefinitionValidationError, 'Each entry in \'container_definitions\' must be a hash.'
+            end
+
             load_container_environment_from_files!(container_definition, base_dir)
           end
         end

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -142,7 +142,7 @@ module Genova
         end
 
         def parse_yaml_environment_file(path)
-          yaml = YAML.unsafe_load(File.read(path))
+          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: %i[name value], aliases: false)
 
           case yaml
           when Hash

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -134,8 +134,10 @@ module Genova
           case File.extname(path)
           when '.yml', '.yaml'
             parse_yaml_environment_file(path)
-          else
+          when '.env', '.dotenv'
             parse_dotenv_environment_file(path)
+          else
+            raise ArgumentError, "Unsupported environment file extension: #{File.extname(path)} [#{path}]"
           end
         end
 

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -15,6 +15,7 @@ module Genova
 
           yaml = YAML.unsafe_load(File.read(path))
           task_definition = Oj.load(Oj.dump(yaml), symbol_keys: true)
+          load_environment_from_files!(task_definition, path)
           merge_task_parameters!(task_definition, task_overrides) if task_overrides.present?
 
           replace_parameter_variables!(task_definition, params)
@@ -85,6 +86,81 @@ module Genova
           override_container_definition[:environment].each do |environment|
             container_definition[:environment].delete_if { |k, _v| k[:name] == environment[:name] }
           end
+        end
+
+        def load_environment_from_files!(task_definition, task_definition_path)
+          raise Exceptions::TaskDefinitionValidationError, '\'container_definitions\' is undefined.' unless task_definition.key?(:container_definitions)
+
+          base_dir = Pathname(task_definition_path).dirname
+
+          task_definition[:container_definitions].each do |container_definition|
+            load_container_environment_from_files!(container_definition, base_dir)
+          end
+        end
+
+        def load_container_environment_from_files!(container_definition, base_dir)
+          environment_file_paths = Array(container_definition.delete(:environment_from_files)).compact
+          return if environment_file_paths.empty?
+
+          file_environments = environment_file_paths.each_with_object([]) do |environment_file_path, environments|
+            resolved_path = File.expand_path(environment_file_path, base_dir)
+            current_environments = read_environment_file(resolved_path)
+            merge_container_environment!({ environment: environments }, { environment: current_environments })
+            environments.concat(current_environments)
+          end
+
+          container_definition[:environment] ||= []
+          merge_container_environment!({ environment: file_environments }, container_definition)
+          container_definition[:environment] = file_environments + container_definition[:environment]
+        end
+
+        def read_environment_file(path)
+          raise Exceptions::TaskDefinitionValidationError, "Environment file does not exist. [#{path}]" unless File.file?(path)
+
+          case File.extname(path)
+          when '.yml', '.yaml'
+            parse_yaml_environment_file(path)
+          else
+            parse_dotenv_environment_file(path)
+          end
+        end
+
+        def parse_yaml_environment_file(path)
+          yaml = YAML.unsafe_load(File.read(path))
+
+          case yaml
+          when Hash
+            yaml.map { |name, value| { name: name.to_s, value: value } }
+          when Array
+            yaml.map do |environment|
+              has_string_keys = environment.is_a?(Hash) && environment.key?('name') && environment.key?('value')
+              has_symbol_keys = environment.is_a?(Hash) && environment.key?(:name) && environment.key?(:value)
+              raise Exceptions::TaskDefinitionValidationError, "Invalid environment entry. [#{path}]" unless has_string_keys || has_symbol_keys
+
+              {
+                name: environment.key?('name') ? environment['name'] : environment[:name],
+                value: environment.key?('value') ? environment['value'] : environment[:value]
+              }
+            end
+          else
+            raise Exceptions::TaskDefinitionValidationError, "Environment file must be a hash or array. [#{path}]"
+          end
+        end
+
+        def parse_dotenv_environment_file(path)
+          environments = []
+
+          File.read(path).each_line do |line|
+            line = line.strip
+            next if line.blank? || line.start_with?('#')
+
+            name, value = line.split('=', 2)
+            raise Exceptions::TaskDefinitionValidationError, "Invalid environment line. [#{path}]" if name.blank?
+
+            environments << { name: name, value: value.to_s }
+          end
+
+          environments
         end
 
         def replace_parameter_variables!(variables, params = {})

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -106,11 +106,18 @@ module Genova
         end
 
         def load_container_environment_from_files!(container_definition, base_dir)
-          environment_file_paths = Array(container_definition.delete(:environment_from_files)).compact
+          environment_file_paths = Array(container_definition.delete(:environment_from_files))
           return if environment_file_paths.empty?
 
+          container_identifier = container_definition[:name] || container_definition['name'] || '(unknown)'
           file_environments = environment_file_paths.each_with_object([]) do |environment_file_path, environments|
-            resolved_path = File.expand_path(environment_file_path, base_dir)
+            resolved_environment_file_path = environment_file_path.respond_to?(:to_str) ? environment_file_path.to_str : environment_file_path
+            unless resolved_environment_file_path.is_a?(String) && resolved_environment_file_path.present?
+              raise Exceptions::TaskDefinitionValidationError,
+                    "Invalid environment file path for container '#{container_identifier}'. [#{environment_file_path.inspect}]"
+            end
+
+            resolved_path = File.expand_path(resolved_environment_file_path, base_dir)
             current_environments = read_environment_file(resolved_path)
             merge_container_environment!({ environment: environments }, { environment: current_environments })
             environments.concat(current_environments)

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -221,6 +221,36 @@ module Genova
         describe 'load_environment_from_files!' do
           let(:task_definition_path) { '/repo/config/deploy/web.yml' }
 
+          it 'should raise error when container_definitions is nil' do
+            variables = {
+              container_definitions: nil
+            }
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, "'container_definitions' must be an array.")
+          end
+
+          it 'should raise error when container_definitions is not an array' do
+            variables = {
+              container_definitions: {}
+            }
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, "'container_definitions' must be an array.")
+          end
+
+          it 'should raise error when container_definition is not a hash' do
+            variables = {
+              container_definitions: ['invalid']
+            }
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, "Each entry in 'container_definitions' must be a hash.")
+          end
+
           it 'should raise error when environment file does not exist' do
             variables = {
               container_definitions: [

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -266,6 +266,36 @@ module Genova
               task_client.send(:load_environment_from_files!, variables, task_definition_path)
             end.to raise_error(Exceptions::TaskDefinitionValidationError, 'Environment file does not exist. [/repo/config/deploy/missing.env]')
           end
+
+          it 'should raise error when environment file path is nil' do
+            variables = {
+              container_definitions: [
+                {
+                  name: 'app',
+                  environment_from_files: [nil]
+                }
+              ]
+            }
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, "Invalid environment file path for container 'app'. [nil]")
+          end
+
+          it 'should raise error when environment file path is empty' do
+            variables = {
+              container_definitions: [
+                {
+                  name: 'app',
+                  environment_from_files: ['']
+                }
+              ]
+            }
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, "Invalid environment file path for container 'app'. [\"\"]")
+          end
         end
       end
     end

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -31,6 +31,69 @@ module Genova
 
             expect(task_client.register(any_args)).to be_a(task_definition.class)
           end
+
+          it 'should load environment from external files' do
+            task_definition_path = '/repo/config/deploy/web.yml'
+            env_file_path = '/repo/config/deploy/app.env'
+            yaml_file_path = '/repo/config/deploy/shared.yml'
+
+            allow(File).to receive(:file?).with(task_definition_path).and_return(true)
+            allow(File).to receive(:file?).with(env_file_path).and_return(true)
+            allow(File).to receive(:file?).with(yaml_file_path).and_return(true)
+            allow(File).to receive(:read).with(task_definition_path).and_return(
+              {
+                container_definitions: [
+                  {
+                    name: 'app',
+                    environment_from_files: [
+                      './app.env',
+                      './shared.yml'
+                    ],
+                    environment: [
+                      {
+                        name: 'INLINE_ONLY',
+                        value: 'inline'
+                      },
+                      {
+                        name: 'SHARED_KEY',
+                        value: 'inline_override'
+                      }
+                    ]
+                  }
+                ]
+              }.to_yaml
+            )
+            allow(File).to receive(:read).with(env_file_path).and_return("DOTENV_KEY=dotenv\nFILE_OVERRIDE=dotenv\nSHARED_KEY=dotenv\n")
+            allow(File).to receive(:read).with(yaml_file_path).and_return(
+              {
+                'YAML_KEY' => 1,
+                'FILE_OVERRIDE' => 'yaml',
+                'SHARED_KEY' => 'yaml'
+              }.to_yaml
+            )
+
+            allow(cipher).to receive(:encrypt_format?).and_return(false)
+            allow(task_definition).to receive(:[]).with(:task_definition_arn)
+            allow(register_task_definition_response).to receive(:[]).with(:task_definition).and_return(task_definition)
+            expect(ecs_client).to receive(:register_task_definition).with(
+              hash_including(
+                container_definitions: [
+                  hash_including(
+                    name: 'app',
+                    environment: [
+                      { name: 'DOTENV_KEY', value: 'dotenv' },
+                      { name: 'FILE_OVERRIDE', value: 'yaml' },
+                      { name: 'YAML_KEY', value: '1' },
+                      { name: 'INLINE_ONLY', value: 'inline' },
+                      { name: 'SHARED_KEY', value: 'inline_override' }
+                    ]
+                  )
+                ]
+              )
+            ).and_return(register_task_definition_response)
+
+            expect(task_client.register(task_definition_path)).to be_a(task_definition.class)
+          end
         end
 
         describe 'merge_task_parameters!' do
@@ -152,6 +215,26 @@ module Genova
           it 'should return decrypted value' do
             task_client.send(:decrypt_environment_variables!, variables)
             expect(variables[:container_definitions][0][:environment][2][:value]).to eq('decrypted_value')
+          end
+        end
+
+        describe 'load_environment_from_files!' do
+          let(:task_definition_path) { '/repo/config/deploy/web.yml' }
+
+          it 'should raise error when environment file does not exist' do
+            variables = {
+              container_definitions: [
+                {
+                  environment_from_files: ['./missing.env']
+                }
+              ]
+            }
+
+            allow(File).to receive(:file?).with('/repo/config/deploy/missing.env').and_return(false)
+
+            expect do
+              task_client.send(:load_environment_from_files!, variables, task_definition_path)
+            end.to raise_error(Exceptions::TaskDefinitionValidationError, 'Environment file does not exist. [/repo/config/deploy/missing.env]')
           end
         end
       end

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -75,22 +75,22 @@ module Genova
             allow(cipher).to receive(:encrypt_format?).and_return(false)
             allow(task_definition).to receive(:[]).with(:task_definition_arn)
             allow(register_task_definition_response).to receive(:[]).with(:task_definition).and_return(task_definition)
-            expect(ecs_client).to receive(:register_task_definition).with(
-              hash_including(
-                container_definitions: [
-                  hash_including(
-                    name: 'app',
-                    environment: [
-                      { name: 'DOTENV_KEY', value: 'dotenv' },
-                      { name: 'FILE_OVERRIDE', value: 'yaml' },
-                      { name: 'YAML_KEY', value: '1' },
-                      { name: 'INLINE_ONLY', value: 'inline' },
-                      { name: 'SHARED_KEY', value: 'inline_override' }
-                    ]
-                  )
-                ]
+            expect(ecs_client).to receive(:register_task_definition) do |params|
+              container_definition = params[:container_definitions].find { |definition| definition[:name] == 'app' }
+
+              expect(container_definition).to include(name: 'app')
+              expect(
+                container_definition[:environment].to_h { |environment| [environment[:name], environment[:value]] }
+              ).to eq(
+                'DOTENV_KEY' => 'dotenv',
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => '1',
+                'INLINE_ONLY' => 'inline',
+                'SHARED_KEY' => 'inline_override'
               )
-            ).and_return(register_task_definition_response)
+
+              register_task_definition_response
+            end
 
             expect(task_client.register(task_definition_path)).to be_a(task_definition.class)
           end


### PR DESCRIPTION
- #451

config/deploy/*.yml の container_definitions に environment_from_files を追加できるようにしました。実装は client.rb:13 に入れてあり、タスク定義読込時に外部ファイルを展開してから既存の environment とマージします。外部ファイル
  はタスク定義YAMLからの相対パスで解決し、.env と .yml / .yaml を読めます。優先順位は「後ろの外部ファイルが前の外部ファイルを上書き」「inline の environment が最後に上書き」です。異常系のスペックも client_spec.rb:19 に追加しま
  した。
使い方はこうです。

```
container_definitions:
  - name: web
    environment_from_files:
      - ./shared.env
      - ./secrets.yml
    environment:
      - name: RAILS_ENV
        value: production
      - name: APP_NAME
        value: genova
```

shared.env は KEY=value 形式、secrets.yml は次のどちらでも読めます。
```
DATABASE_URL: xxx
REDIS_URL: yyy

- name: DATABASE_URL
  value: xxx
- name: REDIS_URL
  value: yyy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variables can be loaded from external YAML and dotenv files and merged into container environments; file-derived entries take precedence and are applied before task registration.
  * Added validation and error handling for missing/invalid environment files and malformed container definitions.

* **Tests**
  * Comprehensive tests for file parsing, merge precedence, registration behavior, and validation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->