### PR TITLE
environment and secrets to external files container overrides

### DIFF
--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -74,6 +74,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "required": ["name"],
         "properties": {
           "name": { "type": "string" },
           "command": {

--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -43,6 +43,39 @@
           }
         }
       }
+    },
+    "container_override_environment": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "patternProperties": {
+          ".+": {
+            "oneOf": [
+              { "type": "number" },
+              { "type": "string" },
+              { "type": "boolean" }
+            ]
+          }
+        }
+      }
+    },
+    "container_overrides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "command": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "environment": { "$ref": "#/definitions/container_override_environment" },
+          "environment_from_files": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
     }
   },
   "type": "object",
@@ -90,6 +123,7 @@
                   "task_role": { "type": "string" },
                   "task_execution_role": { "type": "string" },
                   "containers": { "$ref": "#/definitions/containers" },
+                  "container_overrides": { "$ref": "#/definitions/container_overrides" },
                   "network_configuration": {
                     "type": "object",
                     "required": ["awsvpc_configuration"],
@@ -164,19 +198,7 @@
                       "path": { "type": "string" },
                       "task_overrides": { "type": "object" },
                       "desired_count": { "type": "number" },
-                      "container_overrides": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": { "type": "string" },
-                            "command": {
-                              "type": "array",
-                              "items": { "type": "string" }
-                            }
-                          }
-                        }
-                      },
+                      "container_overrides": { "$ref": "#/definitions/container_overrides" },
                       "containers": { "$ref": "#/definitions/containers" },
                       "latest_submodule": { "type": "boolean" }
                     }

--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -152,6 +152,7 @@
                   "path": { "type": "string" },
                   "task_overrides": { "type": "object" },
                   "containers": { "$ref": "#/definitions/containers" },
+                  "container_overrides": { "$ref": "#/definitions/container_overrides" },
                   "desired_count": { "type": "number" },
                   "force_new_deployment": { "type": "boolean" },
                   "health_check_grace_period_seconds": { "type": "number" },

--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -59,6 +59,17 @@
         }
       }
     },
+    "container_override_secrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "patternProperties": {
+          ".+": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "container_overrides": {
       "type": "array",
       "items": {
@@ -70,7 +81,12 @@
             "items": { "type": "string" }
           },
           "environment": { "$ref": "#/definitions/container_override_environment" },
+          "secrets": { "$ref": "#/definitions/container_override_secrets" },
           "environment_from_files": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "secrets_from_files": {
             "type": "array",
             "items": { "type": "string" }
           }

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -212,25 +212,9 @@ module Genova
         end
 
         if container_definition.present?
-          merged_environment = Ecs::NamedEntries.merge(
-            container_definition[:environment],
-            override_container_definition[:environment]
-          )
-          merged_secrets = Ecs::NamedEntries.merge(
-            container_definition[:secrets],
-            override_container_definition[:secrets]
-          )
-          container_definition.deep_merge!(override_container_definition.except(:environment, :secrets))
-          if merged_environment.present?
-            container_definition[:environment] = merged_environment
-          else
-            container_definition.delete(:environment)
-          end
-          if merged_secrets.present?
-            container_definition[:secrets] = merged_secrets
-          else
-            container_definition.delete(:secrets)
-          end
+          merged = Ecs::NamedEntries.merge_container_entries(container_definition, override_container_definition)
+          container_definition.deep_merge!(override_container_definition.except(*merged.keys))
+          Ecs::NamedEntries.assign_container_entries!(container_definition, merged)
         else
           task_overrides[:container_definitions] << override_container_definition
         end

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -194,9 +194,7 @@ module Genova
         return if config[:container_overrides].blank?
 
         task_overrides = (config[:task_overrides] || {}).deep_dup.deep_symbolize_keys
-        task_overrides[:container_definitions] = Array(task_overrides[:container_definitions]).map do |container_definition|
-          container_definition.deep_dup.deep_symbolize_keys
-        end
+        task_overrides[:container_definitions] = Array(task_overrides[:container_definitions])
 
         config[:container_overrides].each do |container_override|
           apply_container_override_to_task_overrides!(task_overrides, container_override)
@@ -212,19 +210,28 @@ module Genova
         end
 
         if container_definition.present?
-          merge_container_override_environment!(container_definition, override_container_definition)
-          container_definition.deep_merge!(override_container_definition)
+          merged_environment = merge_task_override_environments(
+            container_definition[:environment],
+            override_container_definition[:environment]
+          )
+          container_definition.deep_merge!(override_container_definition.except(:environment))
+          if merged_environment.present?
+            container_definition[:environment] = merged_environment
+          else
+            container_definition.delete(:environment)
+          end
         else
           task_overrides[:container_definitions] << override_container_definition
         end
       end
 
-      def merge_container_override_environment!(container_definition, override_container_definition)
-        return unless container_definition[:environment].present? && override_container_definition[:environment].present?
-
-        override_container_definition[:environment].each do |environment|
-          container_definition[:environment].delete_if { |current_environment| current_environment[:name] == environment[:name] }
+      def merge_task_override_environments(base_environment, override_environment)
+        result = Array(base_environment).deep_dup
+        Array(override_environment).each do |env|
+          result.delete_if { |existing| existing[:name] == env[:name] }
+          result << env
         end
+        result
       end
     end
   end

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -24,7 +24,8 @@ module Genova
         @logger.info('Start run task.')
         ready(:run_task)
 
-        run_task_config = @code_manager.deploy_config.find_run_task(@deploy_job.cluster, @deploy_job.run_task)
+        run_task_config = @code_manager.deploy_config.find_run_task(@deploy_job.cluster, @deploy_job.run_task).deep_dup
+        resolve_container_overrides!(run_task_config)
 
         if @deploy_job.override_container.present?
           run_task_config[:container_overrides] = [
@@ -86,7 +87,12 @@ module Genova
         ready(:scheduled_task)
 
         deploy_config = @code_manager.deploy_config
-        target_config = deploy_config.find_scheduled_task_target(@deploy_job.cluster, @deploy_job.scheduled_task_rule, @deploy_job.scheduled_task_target)
+        target_config = deploy_config.find_scheduled_task_target(
+          @deploy_job.cluster,
+          @deploy_job.scheduled_task_rule,
+          @deploy_job.scheduled_task_target
+        ).deep_dup
+        resolve_container_overrides!(target_config)
 
         task_definition_path = @code_manager.task_definition_config_path("config/#{target_config[:path]}")
         task_definition = create_task(task_definition_path, target_config[:task_overrides], @deploy_job.label)
@@ -165,6 +171,20 @@ module Genova
         raise Interrupt if @deploy_job.status == DeployJob.status.find_value(:reserved_cancel)
 
         @deploy_job.update_status_deploying
+      end
+
+      def resolve_container_overrides!(config)
+        container_overrides_config = config[:container_overrides] || config[:overrides]
+        return unless container_overrides_config.present?
+
+        config[:container_overrides] = Ecs::ContainerOverrideBuilder.build(
+          container_overrides_config,
+          base_dir: deploy_config_base_dir
+        )
+      end
+
+      def deploy_config_base_dir
+        File.expand_path(Pathname(@code_manager.base_path).join('config').to_s)
       end
     end
   end

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -221,9 +221,11 @@ module Genova
       end
 
       def runtime_container_overrides(container_overrides)
-        Array(container_overrides).map do |container_override|
+        normalized_overrides = Array(container_overrides).map do |container_override|
           container_override.deep_dup.deep_symbolize_keys.except(:secrets, :secrets_from_files)
-        end.reject { |container_override| container_override.except(:name).blank? }
+        end
+
+        normalized_overrides.reject { |container_override| container_override.except(:name).blank? }
       end
     end
   end

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -26,6 +26,7 @@ module Genova
 
         run_task_config = @code_manager.deploy_config.find_run_task(@deploy_job.cluster, @deploy_job.run_task).deep_dup
         resolve_container_overrides!(run_task_config)
+        merge_container_overrides_into_task_overrides!(run_task_config)
 
         if @deploy_job.override_container.present?
           run_task_config[:container_overrides] = [
@@ -44,7 +45,7 @@ module Genova
         options = {
           desired_count: run_task_config[:desired_count],
           group: run_task_config[:group],
-          container_overrides: run_task_config[:container_overrides],
+          container_overrides: runtime_container_overrides(run_task_config[:container_overrides]),
           network_configuration: run_task_config[:network_configuration]
         }
         options[:launch_type] = run_task_config[:launch_type] if run_task_config[:launch_type].present?
@@ -96,6 +97,7 @@ module Genova
           @deploy_job.scheduled_task_target
         ).deep_dup
         resolve_container_overrides!(target_config)
+        merge_container_overrides_into_task_overrides!(target_config)
 
         task_definition_path = @code_manager.task_definition_config_path("config/#{target_config[:path]}")
         task_definition = create_task(task_definition_path, target_config[:task_overrides], @deploy_job.label)
@@ -204,7 +206,7 @@ module Genova
       end
 
       def apply_container_override_to_task_overrides!(task_overrides, container_override)
-        override_container_definition = container_override.deep_dup.deep_symbolize_keys.except(:environment_from_files)
+        override_container_definition = container_override.deep_dup.deep_symbolize_keys.except(:environment_from_files, :secrets_from_files)
         container_definition = task_overrides[:container_definitions].find do |current_container_definition|
           current_container_definition[:name] == override_container_definition[:name]
         end
@@ -214,11 +216,20 @@ module Genova
             container_definition[:environment],
             override_container_definition[:environment]
           )
-          container_definition.deep_merge!(override_container_definition.except(:environment))
+          merged_secrets = merge_task_override_named_entries(
+            container_definition[:secrets],
+            override_container_definition[:secrets]
+          )
+          container_definition.deep_merge!(override_container_definition.except(:environment, :secrets))
           if merged_environment.present?
             container_definition[:environment] = merged_environment
           else
             container_definition.delete(:environment)
+          end
+          if merged_secrets.present?
+            container_definition[:secrets] = merged_secrets
+          else
+            container_definition.delete(:secrets)
           end
         else
           task_overrides[:container_definitions] << override_container_definition
@@ -226,12 +237,22 @@ module Genova
       end
 
       def merge_task_override_environments(base_environment, override_environment)
-        result = Array(base_environment).deep_dup
-        Array(override_environment).each do |env|
-          result.delete_if { |existing| existing[:name] == env[:name] }
-          result << env
+        merge_task_override_named_entries(base_environment, override_environment)
+      end
+
+      def merge_task_override_named_entries(base_entries, override_entries)
+        result = Array(base_entries).deep_dup
+        Array(override_entries).each do |entry|
+          result.delete_if { |existing| existing[:name] == entry[:name] }
+          result << entry
         end
         result
+      end
+
+      def runtime_container_overrides(container_overrides)
+        Array(container_overrides).map do |container_override|
+          container_override.deep_dup.deep_symbolize_keys.except(:secrets, :secrets_from_files)
+        end.reject { |container_override| container_override.except(:name).blank? }
       end
     end
   end

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -212,11 +212,11 @@ module Genova
         end
 
         if container_definition.present?
-          merged_environment = merge_task_override_environments(
+          merged_environment = Ecs::NamedEntries.merge(
             container_definition[:environment],
             override_container_definition[:environment]
           )
-          merged_secrets = merge_task_override_named_entries(
+          merged_secrets = Ecs::NamedEntries.merge(
             container_definition[:secrets],
             override_container_definition[:secrets]
           )
@@ -234,19 +234,6 @@ module Genova
         else
           task_overrides[:container_definitions] << override_container_definition
         end
-      end
-
-      def merge_task_override_environments(base_environment, override_environment)
-        merge_task_override_named_entries(base_environment, override_environment)
-      end
-
-      def merge_task_override_named_entries(base_entries, override_entries)
-        result = Array(base_entries).deep_dup
-        Array(override_entries).each do |entry|
-          result.delete_if { |existing| existing[:name] == entry[:name] }
-          result << entry
-        end
-        result
       end
 
       def runtime_container_overrides(container_overrides)

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -61,7 +61,10 @@ module Genova
         @logger.info('Start deploy service.')
         ready(:service)
 
-        service_config = @code_manager.deploy_config.find_service(@deploy_job.cluster, @deploy_job.service)
+        service_config = @code_manager.deploy_config.find_service(@deploy_job.cluster, @deploy_job.service).deep_dup
+        resolve_container_overrides!(service_config)
+        merge_container_overrides_into_task_overrides!(service_config)
+
         task_definition_path = @code_manager.task_definition_config_path("config/#{service_config[:path]}")
         task_definition = create_task(task_definition_path, service_config[:task_overrides], @deploy_job.label)
 
@@ -185,6 +188,43 @@ module Genova
 
       def deploy_config_base_dir
         File.expand_path(Pathname(@code_manager.base_path).join('config').to_s)
+      end
+
+      def merge_container_overrides_into_task_overrides!(config)
+        return if config[:container_overrides].blank?
+
+        task_overrides = (config[:task_overrides] || {}).deep_dup.deep_symbolize_keys
+        task_overrides[:container_definitions] = Array(task_overrides[:container_definitions]).map do |container_definition|
+          container_definition.deep_dup.deep_symbolize_keys
+        end
+
+        config[:container_overrides].each do |container_override|
+          apply_container_override_to_task_overrides!(task_overrides, container_override)
+        end
+
+        config[:task_overrides] = task_overrides
+      end
+
+      def apply_container_override_to_task_overrides!(task_overrides, container_override)
+        override_container_definition = container_override.deep_dup.deep_symbolize_keys.except(:environment_from_files)
+        container_definition = task_overrides[:container_definitions].find do |current_container_definition|
+          current_container_definition[:name] == override_container_definition[:name]
+        end
+
+        if container_definition.present?
+          merge_container_override_environment!(container_definition, override_container_definition)
+          container_definition.deep_merge!(override_container_definition)
+        else
+          task_overrides[:container_definitions] << override_container_definition
+        end
+      end
+
+      def merge_container_override_environment!(container_definition, override_container_definition)
+        return unless container_definition[:environment].present? && override_container_definition[:environment].present?
+
+        override_container_definition[:environment].each do |environment|
+          container_definition[:environment].delete_if { |current_environment| current_environment[:name] == environment[:name] }
+        end
       end
     end
   end

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -1,0 +1,144 @@
+module Genova
+  module Ecs
+    class ContainerOverrideBuilder
+      class << self
+        def build(container_overrides_config, base_dir:)
+          return [] if container_overrides_config.blank?
+          raise Exceptions::ValidationError, "'container_overrides' must be an array." unless container_overrides_config.is_a?(Array)
+
+          container_overrides_config.map do |container_override_config|
+            build_container_override(container_override_config, base_dir)
+          end
+        end
+
+        private
+
+        def build_container_override(container_override_config, base_dir)
+          unless container_override_config.is_a?(Hash)
+            raise Exceptions::ValidationError, "Each entry in 'container_overrides' must be a hash. [#{container_override_config.inspect}]"
+          end
+
+          container_override = container_override_config.deep_dup.deep_symbolize_keys
+          container_identifier = container_override[:name] || '(unknown)'
+
+          file_environments = load_environment_from_files!(
+            container_override.delete(:environment_from_files),
+            base_dir,
+            container_identifier
+          )
+          inline_environments = normalize_environments(container_override[:environment], container_identifier)
+          merged_environments = merge_environments(file_environments, inline_environments)
+
+          if merged_environments.present?
+            container_override[:environment] = merged_environments
+          else
+            container_override.delete(:environment)
+          end
+
+          container_override
+        end
+
+        def load_environment_from_files!(environment_file_paths, base_dir, container_identifier)
+          Array(environment_file_paths).each_with_object([]) do |environment_file_path, environments|
+            resolved_environment_file_path = environment_file_path.respond_to?(:to_str) ? environment_file_path.to_str : environment_file_path
+            unless resolved_environment_file_path.is_a?(String) && resolved_environment_file_path.present?
+              raise Exceptions::ValidationError,
+                    "Invalid environment file path for container override '#{container_identifier}'. [#{environment_file_path.inspect}]"
+            end
+
+            resolved_path = File.expand_path(resolved_environment_file_path, base_dir)
+            current_environments = read_environment_file(resolved_path)
+            environments.replace(merge_environments(environments, current_environments))
+          end
+        end
+
+        def normalize_environments(environments, container_identifier)
+          Array(environments).each_with_object([]) do |environment, normalized|
+            unless environment.is_a?(Hash)
+              raise Exceptions::ValidationError,
+                    "Invalid environment entry for container override '#{container_identifier}'. [#{environment.inspect}]"
+            end
+
+            env_hash = environment.deep_symbolize_keys
+            if env_hash.keys.sort == %i[name value]
+              normalized << {
+                name: env_hash[:name].to_s,
+                value: normalize_environment_value(env_hash[:value])
+              }
+              next
+            end
+
+            env_hash.each do |env_name, env_value|
+              normalized << {
+                name: env_name.to_s,
+                value: normalize_environment_value(env_value)
+              }
+            end
+          end
+        end
+
+        def merge_environments(base_environments, override_environments)
+          merged_environments = base_environments.deep_dup
+
+          override_environments.each do |environment|
+            merged_environments.delete_if { |current_environment| current_environment[:name] == environment[:name] }
+            merged_environments << environment
+          end
+
+          merged_environments
+        end
+
+        def read_environment_file(path)
+          raise Exceptions::ValidationError, "Environment file does not exist. [#{path}]" unless File.file?(path)
+
+          case File.extname(path)
+          when '.yml', '.yaml'
+            parse_yaml_environment_file(path)
+          when '.env', '.dotenv'
+            parse_dotenv_environment_file(path)
+          else
+            raise Exceptions::ValidationError, "Unsupported environment file extension: #{File.extname(path)} [#{path}]"
+          end
+        end
+
+        def parse_yaml_environment_file(path)
+          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: %i[name value], aliases: false)
+
+          case yaml
+          when Hash
+            yaml.map { |name, value| { name: name.to_s, value: normalize_environment_value(value) } }
+          when Array
+            yaml.map do |environment|
+              has_string_keys = environment.is_a?(Hash) && environment.key?('name') && environment.key?('value')
+              has_symbol_keys = environment.is_a?(Hash) && environment.key?(:name) && environment.key?(:value)
+              raise Exceptions::ValidationError, "Invalid environment entry. [#{path}]" unless has_string_keys || has_symbol_keys
+
+              {
+                name: environment.key?('name') ? environment['name'].to_s : environment[:name].to_s,
+                value: normalize_environment_value(environment.key?('value') ? environment['value'] : environment[:value])
+              }
+            end
+          else
+            raise Exceptions::ValidationError, "Environment file must be a hash or array. [#{path}]"
+          end
+        end
+
+        def parse_dotenv_environment_file(path)
+          File.read(path).each_line.each_with_object([]) do |line, environments|
+            line = line.strip
+            next if line.blank? || line.start_with?('#')
+
+            name, value = line.split('=', 2)
+            raise Exceptions::ValidationError, "Invalid environment line. [#{path}]" if name.blank?
+
+            environments << { name:, value: value.to_s }
+          end
+        end
+
+        def normalize_environment_value(value)
+          value.is_a?(String) ? value : value.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -40,13 +40,12 @@ module Genova
 
         def load_environment_from_files!(environment_file_paths, base_dir, container_identifier)
           Array(environment_file_paths).each_with_object([]) do |environment_file_path, environments|
-            resolved_environment_file_path = environment_file_path.respond_to?(:to_str) ? environment_file_path.to_str : environment_file_path
-            unless resolved_environment_file_path.is_a?(String) && resolved_environment_file_path.present?
+            unless environment_file_path.is_a?(String) && environment_file_path.present?
               raise Exceptions::ValidationError,
                     "Invalid environment file path for container override '#{container_identifier}'. [#{environment_file_path.inspect}]"
             end
 
-            resolved_path = File.expand_path(resolved_environment_file_path, base_dir)
+            resolved_path = File.expand_path(environment_file_path, base_dir)
             current_environments = read_environment_file(resolved_path)
             environments.replace(merge_environments(environments, current_environments))
           end
@@ -129,9 +128,13 @@ module Genova
             next if line.blank? || line.start_with?('#')
 
             name, value = line.split('=', 2)
+            name = name.strip
             raise Exceptions::ValidationError, "Invalid environment line. [#{path}]" if name.blank?
 
-            environments << { name:, value: value.to_s }
+            value = value.to_s.strip
+            value = value[1..-2] if value.length >= 2 && ((value.start_with?('"') && value.end_with?('"')) || (value.start_with?("'") && value.end_with?("'")))
+
+            environments << { name:, value: }
           end
         end
 

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -29,9 +29,7 @@ module Genova
         private
 
         def build_container_override(container_override_config, base_dir)
-          unless container_override_config.is_a?(Hash)
-            raise Exceptions::ValidationError, "Each entry in 'container_overrides' must be a hash. [#{container_override_config.inspect}]"
-          end
+          raise Exceptions::ValidationError, "Each entry in 'container_overrides' must be a hash. [#{container_override_config.inspect}]" unless container_override_config.is_a?(Hash)
 
           container_override = container_override_config.deep_dup.deep_symbolize_keys
           container_identifier = container_override[:name] || '(unknown)'

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -28,11 +28,24 @@ module Genova
           )
           inline_environments = normalize_environments(container_override[:environment], container_identifier)
           merged_environments = merge_environments(file_environments, inline_environments)
+          file_secrets = load_secrets_from_files!(
+            container_override.delete(:secrets_from_files),
+            base_dir,
+            container_identifier
+          )
+          inline_secrets = normalize_secrets(container_override[:secrets], container_identifier)
+          merged_secrets = merge_secrets(file_secrets, inline_secrets)
 
           if merged_environments.present?
             container_override[:environment] = merged_environments
           else
             container_override.delete(:environment)
+          end
+
+          if merged_secrets.present?
+            container_override[:secrets] = merged_secrets
+          else
+            container_override.delete(:secrets)
           end
 
           container_override
@@ -48,6 +61,19 @@ module Genova
             resolved_path = File.expand_path(environment_file_path, base_dir)
             current_environments = read_environment_file(resolved_path)
             environments.replace(merge_environments(environments, current_environments))
+          end
+        end
+
+        def load_secrets_from_files!(secret_file_paths, base_dir, container_identifier)
+          Array(secret_file_paths).each_with_object([]) do |secret_file_path, secrets|
+            unless secret_file_path.is_a?(String) && secret_file_path.present?
+              raise Exceptions::ValidationError,
+                    "Invalid secrets file path for container override '#{container_identifier}'. [#{secret_file_path.inspect}]"
+            end
+
+            resolved_path = File.expand_path(secret_file_path, base_dir)
+            current_secrets = read_secrets_file(resolved_path)
+            secrets.replace(merge_secrets(secrets, current_secrets))
           end
         end
 
@@ -76,6 +102,31 @@ module Genova
           end
         end
 
+        def normalize_secrets(secrets, container_identifier)
+          Array(secrets).each_with_object([]) do |secret, normalized|
+            unless secret.is_a?(Hash)
+              raise Exceptions::ValidationError,
+                    "Invalid secret entry for container override '#{container_identifier}'. [#{secret.inspect}]"
+            end
+
+            secret_hash = secret.deep_symbolize_keys
+            if secret_hash.keys.sort == %i[name value_from]
+              normalized << {
+                name: secret_hash[:name].to_s,
+                value_from: normalize_secret_value(secret_hash[:value_from])
+              }
+              next
+            end
+
+            secret_hash.each do |secret_name, secret_value|
+              normalized << {
+                name: secret_name.to_s,
+                value_from: normalize_secret_value(secret_value)
+              }
+            end
+          end
+        end
+
         def merge_environments(base_environments, override_environments)
           merged_environments = base_environments.deep_dup
 
@@ -85,6 +136,17 @@ module Genova
           end
 
           merged_environments
+        end
+
+        def merge_secrets(base_secrets, override_secrets)
+          merged_secrets = base_secrets.deep_dup
+
+          override_secrets.each do |secret|
+            merged_secrets.delete_if { |current_secret| current_secret[:name] == secret[:name] }
+            merged_secrets << secret
+          end
+
+          merged_secrets
         end
 
         def read_environment_file(path)
@@ -97,6 +159,19 @@ module Genova
             parse_dotenv_environment_file(path)
           else
             raise Exceptions::ValidationError, "Unsupported environment file extension: #{File.extname(path)} [#{path}]"
+          end
+        end
+
+        def read_secrets_file(path)
+          raise Exceptions::ValidationError, "Secrets file does not exist. [#{path}]" unless File.file?(path)
+
+          case File.extname(path)
+          when '.yml', '.yaml'
+            parse_yaml_secrets_file(path)
+          when '.env', '.dotenv'
+            parse_dotenv_secrets_file(path)
+          else
+            raise Exceptions::ValidationError, "Unsupported secrets file extension: #{File.extname(path)} [#{path}]"
           end
         end
 
@@ -122,6 +197,28 @@ module Genova
           end
         end
 
+        def parse_yaml_secrets_file(path)
+          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: %i[name value_from], aliases: false)
+
+          case yaml
+          when Hash
+            yaml.map { |name, value_from| { name: name.to_s, value_from: normalize_secret_value(value_from) } }
+          when Array
+            yaml.map do |secret|
+              has_string_keys = secret.is_a?(Hash) && secret.key?('name') && secret.key?('value_from')
+              has_symbol_keys = secret.is_a?(Hash) && secret.key?(:name) && secret.key?(:value_from)
+              raise Exceptions::ValidationError, "Invalid secrets entry. [#{path}]" unless has_string_keys || has_symbol_keys
+
+              {
+                name: secret.key?('name') ? secret['name'].to_s : secret[:name].to_s,
+                value_from: normalize_secret_value(secret.key?('value_from') ? secret['value_from'] : secret[:value_from])
+              }
+            end
+          else
+            raise Exceptions::ValidationError, "Secrets file must be a hash or array. [#{path}]"
+          end
+        end
+
         def parse_dotenv_environment_file(path)
           File.read(path).each_line.each_with_object([]) do |line, environments|
             line = line.strip
@@ -138,7 +235,27 @@ module Genova
           end
         end
 
+        def parse_dotenv_secrets_file(path)
+          File.read(path).each_line.each_with_object([]) do |line, secrets|
+            line = line.strip
+            next if line.blank? || line.start_with?('#')
+
+            name, value_from = line.split('=', 2)
+            name = name.strip
+            raise Exceptions::ValidationError, "Invalid secrets line. [#{path}]" if name.blank?
+
+            value_from = value_from.to_s.strip
+            value_from = value_from[1..-2] if value_from.length >= 2 && ((value_from.start_with?('"') && value_from.end_with?('"')) || (value_from.start_with?("'") && value_from.end_with?("'")))
+
+            secrets << { name:, value_from: normalize_secret_value(value_from) }
+          end
+        end
+
         def normalize_environment_value(value)
+          value.is_a?(String) ? value : value.to_s
+        end
+
+        def normalize_secret_value(value)
           value.is_a?(String) ? value : value.to_s
         end
       end

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -1,6 +1,21 @@
 module Genova
   module Ecs
     class ContainerOverrideBuilder
+      ENTRY_TYPES = {
+        environment: {
+          file_key: :environment_from_files,
+          file_label: 'environment',
+          entry_label: 'environment',
+          value_key: :value
+        },
+        secrets: {
+          file_key: :secrets_from_files,
+          file_label: 'secrets',
+          entry_label: 'secret',
+          value_key: :value_from
+        }
+      }.freeze
+
       class << self
         def build(container_overrides_config, base_dir:)
           return [] if container_overrides_config.blank?
@@ -20,243 +35,41 @@ module Genova
 
           container_override = container_override_config.deep_dup.deep_symbolize_keys
           container_identifier = container_override[:name] || '(unknown)'
-
-          file_environments = load_environment_from_files!(
-            container_override.delete(:environment_from_files),
-            base_dir,
-            container_identifier
-          )
-          inline_environments = normalize_environments(container_override[:environment], container_identifier)
-          merged_environments = merge_environments(file_environments, inline_environments)
-          file_secrets = load_secrets_from_files!(
-            container_override.delete(:secrets_from_files),
-            base_dir,
-            container_identifier
-          )
-          inline_secrets = normalize_secrets(container_override[:secrets], container_identifier)
-          merged_secrets = merge_secrets(file_secrets, inline_secrets)
-
-          if merged_environments.present?
-            container_override[:environment] = merged_environments
-          else
-            container_override.delete(:environment)
-          end
-
-          if merged_secrets.present?
-            container_override[:secrets] = merged_secrets
-          else
-            container_override.delete(:secrets)
+          ENTRY_TYPES.each_key do |entry_type|
+            assign_named_entries!(container_override, entry_type, base_dir, container_identifier)
           end
 
           container_override
         end
 
-        def load_environment_from_files!(environment_file_paths, base_dir, container_identifier)
-          Array(environment_file_paths).each_with_object([]) do |environment_file_path, environments|
-            unless environment_file_path.is_a?(String) && environment_file_path.present?
-              raise Exceptions::ValidationError,
-                    "Invalid environment file path for container override '#{container_identifier}'. [#{environment_file_path.inspect}]"
-            end
+        def assign_named_entries!(container_override, entry_type, base_dir, container_identifier)
+          entries = resolve_named_entries(container_override, entry_type, base_dir, container_identifier)
 
-            resolved_path = File.expand_path(environment_file_path, base_dir)
-            current_environments = read_environment_file(resolved_path)
-            environments.replace(merge_environments(environments, current_environments))
-          end
-        end
-
-        def load_secrets_from_files!(secret_file_paths, base_dir, container_identifier)
-          Array(secret_file_paths).each_with_object([]) do |secret_file_path, secrets|
-            unless secret_file_path.is_a?(String) && secret_file_path.present?
-              raise Exceptions::ValidationError,
-                    "Invalid secrets file path for container override '#{container_identifier}'. [#{secret_file_path.inspect}]"
-            end
-
-            resolved_path = File.expand_path(secret_file_path, base_dir)
-            current_secrets = read_secrets_file(resolved_path)
-            secrets.replace(merge_secrets(secrets, current_secrets))
-          end
-        end
-
-        def normalize_environments(environments, container_identifier)
-          Array(environments).each_with_object([]) do |environment, normalized|
-            unless environment.is_a?(Hash)
-              raise Exceptions::ValidationError,
-                    "Invalid environment entry for container override '#{container_identifier}'. [#{environment.inspect}]"
-            end
-
-            env_hash = environment.deep_symbolize_keys
-            if env_hash.keys.sort == %i[name value]
-              normalized << {
-                name: env_hash[:name].to_s,
-                value: normalize_environment_value(env_hash[:value])
-              }
-              next
-            end
-
-            env_hash.each do |env_name, env_value|
-              normalized << {
-                name: env_name.to_s,
-                value: normalize_environment_value(env_value)
-              }
-            end
-          end
-        end
-
-        def normalize_secrets(secrets, container_identifier)
-          Array(secrets).each_with_object([]) do |secret, normalized|
-            unless secret.is_a?(Hash)
-              raise Exceptions::ValidationError,
-                    "Invalid secret entry for container override '#{container_identifier}'. [#{secret.inspect}]"
-            end
-
-            secret_hash = secret.deep_symbolize_keys
-            if secret_hash.keys.sort == %i[name value_from]
-              normalized << {
-                name: secret_hash[:name].to_s,
-                value_from: normalize_secret_value(secret_hash[:value_from])
-              }
-              next
-            end
-
-            secret_hash.each do |secret_name, secret_value|
-              normalized << {
-                name: secret_name.to_s,
-                value_from: normalize_secret_value(secret_value)
-              }
-            end
-          end
-        end
-
-        def merge_environments(base_environments, override_environments)
-          merged_environments = base_environments.deep_dup
-
-          override_environments.each do |environment|
-            merged_environments.delete_if { |current_environment| current_environment[:name] == environment[:name] }
-            merged_environments << environment
-          end
-
-          merged_environments
-        end
-
-        def merge_secrets(base_secrets, override_secrets)
-          merged_secrets = base_secrets.deep_dup
-
-          override_secrets.each do |secret|
-            merged_secrets.delete_if { |current_secret| current_secret[:name] == secret[:name] }
-            merged_secrets << secret
-          end
-
-          merged_secrets
-        end
-
-        def read_environment_file(path)
-          raise Exceptions::ValidationError, "Environment file does not exist. [#{path}]" unless File.file?(path)
-
-          case File.extname(path)
-          when '.yml', '.yaml'
-            parse_yaml_environment_file(path)
-          when '.env', '.dotenv'
-            parse_dotenv_environment_file(path)
+          if entries.present?
+            container_override[entry_type] = entries
           else
-            raise Exceptions::ValidationError, "Unsupported environment file extension: #{File.extname(path)} [#{path}]"
+            container_override.delete(entry_type)
           end
         end
 
-        def read_secrets_file(path)
-          raise Exceptions::ValidationError, "Secrets file does not exist. [#{path}]" unless File.file?(path)
+        def resolve_named_entries(container_override, entry_type, base_dir, container_identifier)
+          entry_options = ENTRY_TYPES.fetch(entry_type)
+          file_entries = Ecs::NamedEntries.load_from_files!(
+            container_override.delete(entry_options[:file_key]),
+            base_dir:,
+            container_identifier:,
+            file_label: entry_options[:file_label],
+            entry_label: entry_options[:entry_label],
+            value_key: entry_options[:value_key]
+          )
+          inline_entries = Ecs::NamedEntries.normalize(
+            container_override[entry_type],
+            value_key: entry_options[:value_key],
+            entry_label: entry_options[:entry_label],
+            container_identifier:
+          )
 
-          case File.extname(path)
-          when '.yml', '.yaml'
-            parse_yaml_secrets_file(path)
-          when '.env', '.dotenv'
-            parse_dotenv_secrets_file(path)
-          else
-            raise Exceptions::ValidationError, "Unsupported secrets file extension: #{File.extname(path)} [#{path}]"
-          end
-        end
-
-        def parse_yaml_environment_file(path)
-          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: %i[name value], aliases: false)
-
-          case yaml
-          when Hash
-            yaml.map { |name, value| { name: name.to_s, value: normalize_environment_value(value) } }
-          when Array
-            yaml.map do |environment|
-              has_string_keys = environment.is_a?(Hash) && environment.key?('name') && environment.key?('value')
-              has_symbol_keys = environment.is_a?(Hash) && environment.key?(:name) && environment.key?(:value)
-              raise Exceptions::ValidationError, "Invalid environment entry. [#{path}]" unless has_string_keys || has_symbol_keys
-
-              {
-                name: environment.key?('name') ? environment['name'].to_s : environment[:name].to_s,
-                value: normalize_environment_value(environment.key?('value') ? environment['value'] : environment[:value])
-              }
-            end
-          else
-            raise Exceptions::ValidationError, "Environment file must be a hash or array. [#{path}]"
-          end
-        end
-
-        def parse_yaml_secrets_file(path)
-          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: %i[name value_from], aliases: false)
-
-          case yaml
-          when Hash
-            yaml.map { |name, value_from| { name: name.to_s, value_from: normalize_secret_value(value_from) } }
-          when Array
-            yaml.map do |secret|
-              has_string_keys = secret.is_a?(Hash) && secret.key?('name') && secret.key?('value_from')
-              has_symbol_keys = secret.is_a?(Hash) && secret.key?(:name) && secret.key?(:value_from)
-              raise Exceptions::ValidationError, "Invalid secrets entry. [#{path}]" unless has_string_keys || has_symbol_keys
-
-              {
-                name: secret.key?('name') ? secret['name'].to_s : secret[:name].to_s,
-                value_from: normalize_secret_value(secret.key?('value_from') ? secret['value_from'] : secret[:value_from])
-              }
-            end
-          else
-            raise Exceptions::ValidationError, "Secrets file must be a hash or array. [#{path}]"
-          end
-        end
-
-        def parse_dotenv_environment_file(path)
-          File.read(path).each_line.each_with_object([]) do |line, environments|
-            line = line.strip
-            next if line.blank? || line.start_with?('#')
-
-            name, value = line.split('=', 2)
-            name = name.strip
-            raise Exceptions::ValidationError, "Invalid environment line. [#{path}]" if name.blank?
-
-            value = value.to_s.strip
-            value = value[1..-2] if value.length >= 2 && ((value.start_with?('"') && value.end_with?('"')) || (value.start_with?("'") && value.end_with?("'")))
-
-            environments << { name:, value: }
-          end
-        end
-
-        def parse_dotenv_secrets_file(path)
-          File.read(path).each_line.each_with_object([]) do |line, secrets|
-            line = line.strip
-            next if line.blank? || line.start_with?('#')
-
-            name, value_from = line.split('=', 2)
-            name = name.strip
-            raise Exceptions::ValidationError, "Invalid secrets line. [#{path}]" if name.blank?
-
-            value_from = value_from.to_s.strip
-            value_from = value_from[1..-2] if value_from.length >= 2 && ((value_from.start_with?('"') && value_from.end_with?('"')) || (value_from.start_with?("'") && value_from.end_with?("'")))
-
-            secrets << { name:, value_from: normalize_secret_value(value_from) }
-          end
-        end
-
-        def normalize_environment_value(value)
-          value.is_a?(String) ? value : value.to_s
-        end
-
-        def normalize_secret_value(value)
-          value.is_a?(String) ? value : value.to_s
+          Ecs::NamedEntries.merge(file_entries, inline_entries)
         end
       end
     end

--- a/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
+++ b/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
@@ -14,13 +14,12 @@ module Genova
               clusters = ecs.describe_clusters(clusters: [deploy_job.cluster]).clusters
               raise Exceptions::NotFoundError, "Cluster does not eixst. [#{deploy_job.cluster}]" if clusters.count.zero?
 
-              container_overrides_config = target_config[:overrides] || target_config[:container_overrides]
+              container_overrides_config = target_config[:container_overrides] || target_config[:overrides]
               container_overrides = []
 
               if container_overrides_config.present?
                 container_overrides_config.each do |container_override_config|
-                  override_environment = container_override_config[:environment] || []
-                  container_overrides << override_container(container_override_config[:name], container_override_config[:command], override_environment)
+                  container_overrides << override_container(container_override_config)
                 end
               end
 
@@ -45,23 +44,33 @@ module Genova
 
             private
 
-            def override_container(name, command = nil, environments = {})
-              environment_overrides = []
-              environments.each do |environment|
+            def override_container(container_override_config)
+              container_override = container_override_config.deep_dup.deep_symbolize_keys.except(:environment_from_files)
+              environment_overrides = normalize_environment(container_override[:environment])
+              container_override[:environment] = environment_overrides if environment_overrides.count.positive?
+              container_override.delete(:environment) if environment_overrides.empty?
+              container_override
+            end
+
+            def normalize_environment(environments)
+              Array(environments).each_with_object([]) do |environment, normalized|
+                environment = environment.deep_symbolize_keys
+
+                if environment.keys.sort == %i[name value]
+                  normalized << {
+                    name: environment[:name],
+                    value: environment[:value]
+                  }
+                  next
+                end
+
                 environment.each do |env_name, env_value|
-                  environment_overrides << {
+                  normalized << {
                     name: env_name,
                     value: env_value
                   }
                 end
               end
-
-              container_override = {
-                name:,
-                command:
-              }
-              container_override[:environment] = environment_overrides if environment_overrides.count.positive?
-              container_override
             end
           end
         end

--- a/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
+++ b/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
@@ -50,8 +50,7 @@ module Genova
               environment_overrides = Ecs::NamedEntries.normalize(
                 container_override[:environment],
                 value_key: :value,
-                entry_label: 'environment',
-                value_transform: ->(value) { value }
+                entry_label: 'environment'
               )
               container_override[:environment] = environment_overrides if environment_overrides.count.positive?
               container_override.delete(:environment) if environment_overrides.empty?

--- a/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
+++ b/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
@@ -47,35 +47,18 @@ module Genova
 
             def override_container(container_override_config)
               container_override = container_override_config.deep_dup.deep_symbolize_keys.except(:environment_from_files, :secrets_from_files, :secrets)
-              environment_overrides = normalize_environment(container_override[:environment])
+              environment_overrides = Ecs::NamedEntries.normalize(
+                container_override[:environment],
+                value_key: :value,
+                entry_label: 'environment',
+                value_transform: ->(value) { value }
+              )
               container_override[:environment] = environment_overrides if environment_overrides.count.positive?
               container_override.delete(:environment) if environment_overrides.empty?
               return if container_override.except(:name).blank?
 
               container_override
             end
-
-            def normalize_environment(environments)
-              Array(environments).each_with_object([]) do |environment, normalized|
-                environment = environment.deep_symbolize_keys
-
-                if environment.keys.sort == %i[name value]
-                  normalized << {
-                    name: environment[:name],
-                    value: environment[:value]
-                  }
-                  next
-                end
-
-                environment.each do |env_name, env_value|
-                  normalized << {
-                    name: env_name,
-                    value: env_value
-                  }
-                end
-              end
-            end
-
           end
         end
       end

--- a/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
+++ b/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
@@ -19,7 +19,8 @@ module Genova
 
               if container_overrides_config.present?
                 container_overrides_config.each do |container_override_config|
-                  container_overrides << override_container(container_override_config)
+                  container_override = override_container(container_override_config)
+                  container_overrides << container_override if container_override.present?
                 end
               end
 
@@ -45,10 +46,12 @@ module Genova
             private
 
             def override_container(container_override_config)
-              container_override = container_override_config.deep_dup.deep_symbolize_keys.except(:environment_from_files)
+              container_override = container_override_config.deep_dup.deep_symbolize_keys.except(:environment_from_files, :secrets_from_files, :secrets)
               environment_overrides = normalize_environment(container_override[:environment])
               container_override[:environment] = environment_overrides if environment_overrides.count.positive?
               container_override.delete(:environment) if environment_overrides.empty?
+              return if container_override.except(:name).blank?
+
               container_override
             end
 
@@ -72,6 +75,7 @@ module Genova
                 end
               end
             end
+
           end
         end
       end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -54,15 +54,14 @@ module Genova
         end
       end
 
-      def load_from_files!(
-        file_paths,
-        base_dir:,
-        container_identifier:,
-        file_label:,
-        entry_label:,
-        value_key:,
-        value_transform: method(:stringify_value)
-      )
+      def load_from_files!(file_paths, options = {})
+        base_dir = options.fetch(:base_dir)
+        container_identifier = options.fetch(:container_identifier)
+        file_label = options.fetch(:file_label)
+        entry_label = options.fetch(:entry_label)
+        value_key = options.fetch(:value_key)
+        value_transform = options.fetch(:value_transform, method(:stringify_value))
+
         Array(file_paths).each_with_object([]) do |file_path, entries|
           unless file_path.is_a?(String) && file_path.present?
             raise Exceptions::ValidationError,

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -1,0 +1,143 @@
+module Genova
+  module Ecs
+    module NamedEntries
+      module_function
+
+      def merge(base_entries, override_entries)
+        result = Array(base_entries).deep_dup
+
+        Array(override_entries).each do |entry|
+          result.delete_if { |current_entry| current_entry[:name] == entry[:name] }
+          result << entry
+        end
+
+        result
+      end
+
+      def normalize(entries, value_key:, entry_label:, container_identifier: nil, value_transform: method(:stringify_value))
+        Array(entries).each_with_object([]) do |entry, normalized|
+          unless entry.is_a?(Hash)
+            raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier)
+          end
+
+          entry_hash = entry.deep_symbolize_keys
+          if entry_hash.keys.sort == [:name, value_key].sort
+            normalized << build_entry(entry_hash[:name], entry_hash[value_key], value_key:, value_transform:)
+            next
+          end
+
+          entry_hash.each do |entry_name, entry_value|
+            normalized << build_entry(entry_name, entry_value, value_key:, value_transform:)
+          end
+        end
+      end
+
+      def load_from_files!(
+        file_paths,
+        base_dir:,
+        container_identifier:,
+        file_label:,
+        entry_label:,
+        value_key:,
+        value_transform: method(:stringify_value)
+      )
+        Array(file_paths).each_with_object([]) do |file_path, entries|
+          unless file_path.is_a?(String) && file_path.present?
+            raise Exceptions::ValidationError,
+                  "Invalid #{file_label} file path for container override '#{container_identifier}'. [#{file_path.inspect}]"
+          end
+
+          resolved_path = File.expand_path(file_path, base_dir)
+          current_entries = read_file(
+            resolved_path,
+            file_label:,
+            entry_label:,
+            value_key:,
+            value_transform:
+          )
+          entries.replace(merge(entries, current_entries))
+        end
+      end
+
+      def read_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
+        raise Exceptions::ValidationError, "#{file_label.capitalize} file does not exist. [#{path}]" unless File.file?(path)
+
+        case File.extname(path)
+        when '.yml', '.yaml'
+          parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform:)
+        when '.env', '.dotenv'
+          parse_dotenv_file(path, file_label:, value_key:, value_transform:)
+        else
+          raise Exceptions::ValidationError, "Unsupported #{file_label} file extension: #{File.extname(path)} [#{path}]"
+        end
+      end
+
+      def parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
+        yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [:name, value_key], aliases: false)
+
+        case yaml
+        when Hash
+          yaml.map { |name, value| build_entry(name, value, value_key:, value_transform:) }
+        when Array
+          yaml.map do |entry|
+            has_string_keys = entry.is_a?(Hash) && entry.key?('name') && entry.key?(value_key.to_s)
+            has_symbol_keys = entry.is_a?(Hash) && entry.key?(:name) && entry.key?(value_key)
+            raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless has_string_keys || has_symbol_keys
+
+            build_entry(
+              entry.key?('name') ? entry['name'] : entry[:name],
+              entry.key?(value_key.to_s) ? entry[value_key.to_s] : entry[value_key],
+              value_key:,
+              value_transform:
+            )
+          end
+        else
+          raise Exceptions::ValidationError, "#{file_label.capitalize} file must be a hash or array. [#{path}]"
+        end
+      end
+
+      def parse_dotenv_file(path, file_label:, value_key:, value_transform: method(:stringify_value))
+        File.read(path).each_line.each_with_object([]) do |line, entries|
+          line = line.strip
+          next if line.blank? || line.start_with?('#')
+
+          name, value = line.split('=', 2)
+          name = name.strip
+          raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank?
+
+          entries << build_entry(name, strip_wrapping_quotes(value.to_s.strip), value_key:, value_transform:)
+        end
+      end
+
+      def stringify_value(value)
+        value.is_a?(String) ? value : value.to_s
+      end
+
+      def build_entry(name, value, value_key:, value_transform:)
+        {
+          name: name.to_s,
+          value_key => value_transform.call(value)
+        }
+      end
+      private_class_method :build_entry
+
+      def invalid_entry_message(entry_label, entry, container_identifier)
+        if container_identifier.present?
+          "Invalid #{entry_label} entry for container override '#{container_identifier}'. [#{entry.inspect}]"
+        else
+          "Invalid #{entry_label} entry. [#{entry.inspect}]"
+        end
+      end
+      private_class_method :invalid_entry_message
+
+      def strip_wrapping_quotes(value)
+        return value unless value.length >= 2
+        return value[1..-2] if value.start_with?('"') && value.end_with?('"')
+        return value[1..-2] if value.start_with?("'") && value.end_with?("'")
+
+        value
+      end
+      private_class_method :strip_wrapping_quotes
+    end
+  end
+end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -130,7 +130,7 @@ module Genova
 
           name, value = line.split('=', 2)
           name = name.strip
-          raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank?
+          raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank? || value.nil?
 
           entries << build_entry(name, strip_wrapping_quotes(strip_inline_comment(value.to_s).strip), value_key:, value_transform:)
         end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -3,6 +3,26 @@ module Genova
     module NamedEntries
       module_function
 
+      CONTAINER_ENTRY_KEYS = %i[environment secrets].freeze
+
+      def merge_container_entries(base_definition, override_definition)
+        CONTAINER_ENTRY_KEYS.each_with_object({}) do |entry_key, merged|
+          next unless override_definition[entry_key].present?
+
+          merged[entry_key] = merge(base_definition[entry_key], override_definition[entry_key])
+        end
+      end
+
+      def assign_container_entries!(container_definition, named_entries)
+        named_entries.each do |entry_key, entries|
+          if entries.present?
+            container_definition[entry_key] = entries
+          else
+            container_definition.delete(entry_key)
+          end
+        end
+      end
+
       def merge(base_entries, override_entries)
         result = Array(base_entries).deep_dup
 

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -36,17 +36,13 @@ module Genova
 
       def normalize(entries, value_key:, entry_label:, container_identifier: nil, value_transform: method(:stringify_value))
         Array(entries).each_with_object([]) do |entry, normalized|
-          unless entry.is_a?(Hash)
-            raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier)
-          end
+          raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry.is_a?(Hash)
 
           entry_hash = entry.deep_symbolize_keys
           canonical_keys = %i[name value value_from]
 
           if (entry_hash.keys & canonical_keys).any?
-            unless entry_hash.keys.sort == [:name, value_key].sort
-              raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier)
-            end
+            raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry_hash.keys.sort == [:name, value_key].sort
 
             normalized << build_entry(entry_hash[:name], entry_hash[value_key], value_key:, value_transform:)
             next
@@ -107,9 +103,7 @@ module Genova
           yaml.map { |name, value| build_entry(name, value, value_key:, value_transform:) }
         when Array
           yaml.map do |entry|
-            has_string_keys = entry.is_a?(Hash) && entry.key?('name') && entry.key?(value_key.to_s)
-            has_symbol_keys = entry.is_a?(Hash) && entry.key?(:name) && entry.key?(value_key)
-            raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless has_string_keys || has_symbol_keys
+            raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless valid_yaml_array_entry?(entry, value_key)
 
             build_entry(
               entry.key?('name') ? entry['name'] : entry[:name],
@@ -122,6 +116,21 @@ module Genova
           raise Exceptions::ValidationError, "#{file_label.capitalize} file must be a hash or array. [#{path}]"
         end
       end
+
+      def valid_yaml_array_entry?(entry, value_key)
+        return false unless entry.is_a?(Hash)
+
+        has_string_keys = entry.key?('name') && entry.key?(value_key.to_s)
+        has_symbol_keys = entry.key?(:name) && entry.key?(value_key)
+
+        (entry.keys - allowed_yaml_array_entry_keys(value_key)).empty? && (has_string_keys || has_symbol_keys)
+      end
+      private_class_method :valid_yaml_array_entry?
+
+      def allowed_yaml_array_entry_keys(value_key)
+        ['name', value_key.to_s, :name, value_key]
+      end
+      private_class_method :allowed_yaml_array_entry_keys
 
       def parse_dotenv_file(path, file_label:, value_key:, value_transform: method(:stringify_value))
         File.read(path).each_line.each_with_object([]) do |line, entries|
@@ -141,21 +150,37 @@ module Genova
       end
 
       def build_entry(name, value, value_key:, value_transform:)
+        raise Exceptions::ValidationError, 'Entry name must be present.' if name.nil?
+
+        normalized_name = name.to_s
+        raise Exceptions::ValidationError, 'Entry name must be present.' if normalized_name.strip.empty?
+
         {
-          name: name.to_s,
+          name: normalized_name,
           value_key => value_transform.call(value)
         }
       end
       private_class_method :build_entry
 
       def invalid_entry_message(entry_label, entry, container_identifier)
+        sanitized_entry = sanitize_entry_for_message(entry)
+
         if container_identifier.present?
-          "Invalid #{entry_label} entry for container override '#{container_identifier}'. [#{entry.inspect}]"
+          "Invalid #{entry_label} entry for container override '#{container_identifier}'. [#{sanitized_entry}]"
         else
-          "Invalid #{entry_label} entry. [#{entry.inspect}]"
+          "Invalid #{entry_label} entry. [#{sanitized_entry}]"
         end
       end
       private_class_method :invalid_entry_message
+
+      def sanitize_entry_for_message(entry)
+        return "Hash(size: #{entry.size}, keys: #{entry.keys.inspect})" if entry.is_a?(Hash)
+        return "Array(size: #{entry.size})" if entry.is_a?(Array)
+        return "String(size: #{entry.size})" if entry.is_a?(String)
+
+        entry.inspect
+      end
+      private_class_method :sanitize_entry_for_message
 
       def strip_inline_comment(value)
         in_single_quote = false
@@ -168,13 +193,20 @@ module Genova
           when '"'
             in_double_quote = !in_double_quote unless in_single_quote
           when '#'
-            return value[0, i] unless in_single_quote || in_double_quote
+            return value[0, i] if inline_comment_start?(value, i, in_single_quote, in_double_quote)
           end
         end
 
         value
       end
       private_class_method :strip_inline_comment
+
+      def inline_comment_start?(value, index, in_single_quote, in_double_quote)
+        return false if in_single_quote || in_double_quote
+
+        index.zero? || value[index - 1].match?(/\s/)
+      end
+      private_class_method :inline_comment_start?
 
       def strip_wrapping_quotes(value)
         return value unless value.length >= 2

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -1,236 +1,231 @@
 module Genova
   module Ecs
     module NamedEntries
-      module_function
-
       CONTAINER_ENTRY_KEYS = %i[environment secrets].freeze
 
-      def merge_container_entries(base_definition, override_definition)
-        CONTAINER_ENTRY_KEYS.each_with_object({}) do |entry_key, merged|
-          next unless override_definition[entry_key].present?
+      class << self
+        def merge_container_entries(base_definition, override_definition)
+          CONTAINER_ENTRY_KEYS.each_with_object({}) do |entry_key, merged|
+            next unless override_definition[entry_key].present?
 
-          merged[entry_key] = merge(base_definition[entry_key], override_definition[entry_key])
-        end
-      end
-
-      def assign_container_entries!(container_definition, named_entries)
-        named_entries.each do |entry_key, entries|
-          if entries.present?
-            container_definition[entry_key] = entries
-          else
-            container_definition.delete(entry_key)
+            merged[entry_key] = merge(base_definition[entry_key], override_definition[entry_key])
           end
         end
-      end
 
-      def merge(base_entries, override_entries)
-        result = Array(base_entries).deep_dup
-
-        Array(override_entries).each do |entry|
-          result.delete_if { |current_entry| current_entry[:name] == entry[:name] }
-          result << entry
-        end
-
-        result
-      end
-
-      def normalize(entries, value_key:, entry_label:, container_identifier: nil, value_transform: method(:stringify_value))
-        Array(entries).each_with_object([]) do |entry, normalized|
-          raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry.is_a?(Hash)
-
-          entry_hash = entry.deep_symbolize_keys
-          canonical_keys = %i[name value value_from]
-
-          if (entry_hash.keys & canonical_keys).any?
-            raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry_hash.keys.sort == [:name, value_key].sort
-
-            normalized << build_entry(entry_hash[:name], entry_hash[value_key], value_key:, value_transform:)
-            next
-          end
-
-          entry_hash.each do |entry_name, entry_value|
-            normalized << build_entry(entry_name, entry_value, value_key:, value_transform:)
+        def assign_container_entries!(container_definition, named_entries)
+          named_entries.each do |entry_key, entries|
+            if entries.present?
+              container_definition[entry_key] = entries
+            else
+              container_definition.delete(entry_key)
+            end
           end
         end
-      end
 
-      def load_from_files!(file_paths, options = {})
-        base_dir = options.fetch(:base_dir)
-        container_identifier = options.fetch(:container_identifier)
-        file_label = options.fetch(:file_label)
-        entry_label = options.fetch(:entry_label)
-        value_key = options.fetch(:value_key)
-        value_transform = options.fetch(:value_transform, method(:stringify_value))
+        def merge(base_entries, override_entries)
+          result = Array(base_entries).deep_dup
 
-        Array(file_paths).each_with_object([]) do |file_path, entries|
-          unless file_path.is_a?(String) && file_path.present?
-            raise Exceptions::ValidationError,
-                  "Invalid #{file_label} file path for container override '#{container_identifier}'. [#{file_path.inspect}]"
+          Array(override_entries).each do |entry|
+            result.delete_if { |current_entry| current_entry[:name] == entry[:name] }
+            result << entry
           end
 
-          resolved_path = File.expand_path(file_path, base_dir)
-          validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
-          current_entries = read_file(
-            resolved_path,
-            file_label:,
-            entry_label:,
-            value_key:,
-            value_transform:
-          )
-          entries.replace(merge(entries, current_entries))
+          result
         end
-      end
 
-      def read_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
-        raise Exceptions::ValidationError, "#{file_label.capitalize} file does not exist. [#{path}]" unless File.file?(path)
-
-        case File.extname(path)
-        when '.yml', '.yaml'
-          parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform:)
-        when '.env', '.dotenv'
-          parse_dotenv_file(path, file_label:, value_key:, value_transform:)
-        else
-          raise Exceptions::ValidationError, "Unsupported #{file_label} file extension: #{File.extname(path)} [#{path}]"
-        end
-      end
-
-      def parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
-        yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [:name, value_key], aliases: false)
-
-        case yaml
-        when Hash
-          yaml.map { |name, value| build_entry(name, value, value_key:, value_transform:) }
-        when Array
-          yaml.map do |entry|
-            raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless valid_yaml_array_entry?(entry, value_key)
+        def normalize(entries, value_key:, entry_label:, container_identifier: nil, value_transform: method(:stringify_value))
+          Array(entries).each_with_object([]) do |entry, normalized|
+            raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry.is_a?(Hash)
 
             entry_hash = entry.deep_symbolize_keys
-            build_entry(
-              entry_hash[:name],
-              entry_hash[value_key],
+            canonical_keys = %i[name value value_from]
+
+            if (entry_hash.keys & canonical_keys).any?
+              raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier) unless entry_hash.keys.sort == [:name, value_key].sort
+
+              normalized << build_entry(entry_hash[:name], entry_hash[value_key], value_key:, value_transform:)
+              next
+            end
+
+            entry_hash.each do |entry_name, entry_value|
+              normalized << build_entry(entry_name, entry_value, value_key:, value_transform:)
+            end
+          end
+        end
+
+        def load_from_files!(file_paths, options = {})
+          base_dir = options.fetch(:base_dir)
+          container_identifier = options.fetch(:container_identifier)
+          file_label = options.fetch(:file_label)
+          entry_label = options.fetch(:entry_label)
+          value_key = options.fetch(:value_key)
+          value_transform = options.fetch(:value_transform, method(:stringify_value))
+
+          Array(file_paths).each_with_object([]) do |file_path, entries|
+            unless file_path.is_a?(String) && file_path.present?
+              raise Exceptions::ValidationError,
+                    "Invalid #{file_label} file path for container override '#{container_identifier}'. [#{file_path.inspect}]"
+            end
+
+            resolved_path = File.expand_path(file_path, base_dir)
+            validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
+            current_entries = read_file(
+              resolved_path,
+              file_label:,
+              entry_label:,
               value_key:,
               value_transform:
             )
-          end
-        else
-          raise Exceptions::ValidationError, "#{file_label.capitalize} file must be a hash or array. [#{path}]"
-        end
-      end
-
-      def valid_yaml_array_entry?(entry, value_key)
-        return false unless entry.is_a?(Hash)
-
-        string_keys = ['name', value_key.to_s]
-        symbol_keys = [:name, value_key]
-
-        same_keys?(entry.keys, string_keys) || same_keys?(entry.keys, symbol_keys)
-      end
-      private_class_method :valid_yaml_array_entry?
-
-      def same_keys?(actual_keys, expected_keys)
-        (actual_keys - expected_keys).empty? && (expected_keys - actual_keys).empty?
-      end
-      private_class_method :same_keys?
-
-      def parse_dotenv_file(path, file_label:, value_key:, value_transform: method(:stringify_value))
-        File.read(path).each_line.each_with_object([]) do |line, entries|
-          line = line.strip
-          next if line.blank? || line.start_with?('#')
-
-          name, value = line.split('=', 2)
-          name = name.strip
-          raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank? || value.nil?
-
-          entries << build_entry(name, strip_wrapping_quotes(strip_inline_comment(value.to_s).strip), value_key:, value_transform:)
-        end
-      end
-
-      def stringify_value(value)
-        value.is_a?(String) ? value : value.to_s
-      end
-
-      def build_entry(name, value, value_key:, value_transform:)
-        raise Exceptions::ValidationError, 'Entry name must be present.' if name.nil?
-
-        normalized_name = name.to_s
-        raise Exceptions::ValidationError, 'Entry name must be present.' if normalized_name.strip.empty?
-
-        {
-          name: normalized_name,
-          value_key => value_transform.call(value)
-        }
-      end
-      private_class_method :build_entry
-
-      def invalid_entry_message(entry_label, entry, container_identifier)
-        sanitized_entry = sanitize_entry_for_message(entry)
-
-        if container_identifier.present?
-          "Invalid #{entry_label} entry for container override '#{container_identifier}'. [#{sanitized_entry}]"
-        else
-          "Invalid #{entry_label} entry. [#{sanitized_entry}]"
-        end
-      end
-      private_class_method :invalid_entry_message
-
-      def sanitize_entry_for_message(entry)
-        return "Hash(size: #{entry.size}, keys: #{entry.keys.inspect})" if entry.is_a?(Hash)
-        return "Array(size: #{entry.size})" if entry.is_a?(Array)
-        return "String(size: #{entry.size})" if entry.is_a?(String)
-
-        entry.inspect
-      end
-      private_class_method :sanitize_entry_for_message
-
-      def strip_inline_comment(value)
-        in_single_quote = false
-        in_double_quote = false
-
-        value.each_char.with_index do |char, i|
-          case char
-          when "'"
-            in_single_quote = !in_single_quote unless in_double_quote
-          when '"'
-            in_double_quote = !in_double_quote unless in_single_quote
-          when '#'
-            return value[0, i] if inline_comment_start?(value, i, in_single_quote, in_double_quote)
+            entries.replace(merge(entries, current_entries))
           end
         end
 
-        value
-      end
-      private_class_method :strip_inline_comment
+        def read_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
+          raise Exceptions::ValidationError, "#{file_label.capitalize} file does not exist. [#{path}]" unless File.file?(path)
 
-      def inline_comment_start?(value, index, in_single_quote, in_double_quote)
-        return false if in_single_quote || in_double_quote
+          case File.extname(path)
+          when '.yml', '.yaml'
+            parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform:)
+          when '.env', '.dotenv'
+            parse_dotenv_file(path, file_label:, value_key:, value_transform:)
+          else
+            raise Exceptions::ValidationError, "Unsupported #{file_label} file extension: #{File.extname(path)} [#{path}]"
+          end
+        end
 
-        index.zero? || value[index - 1].match?(/\s/)
-      end
-      private_class_method :inline_comment_start?
+        def parse_yaml_file(path, file_label:, entry_label:, value_key:, value_transform: method(:stringify_value))
+          yaml = YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [:name, value_key], aliases: false)
 
-      def strip_wrapping_quotes(value)
-        return value unless value.length >= 2
-        return value[1..-2] if value.start_with?('"') && value.end_with?('"')
-        return value[1..-2] if value.start_with?("'") && value.end_with?("'")
+          case yaml
+          when Hash
+            yaml.map { |name, value| build_entry(name, value, value_key:, value_transform:) }
+          when Array
+            yaml.map do |entry|
+              raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless valid_yaml_array_entry?(entry, value_key)
 
-        value
-      end
-      private_class_method :strip_wrapping_quotes
+              entry_hash = entry.deep_symbolize_keys
+              build_entry(
+                entry_hash[:name],
+                entry_hash[value_key],
+                value_key:,
+                value_transform:
+              )
+            end
+          else
+            raise Exceptions::ValidationError, "#{file_label.capitalize} file must be a hash or array. [#{path}]"
+          end
+        end
 
-      def validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
-        base_real = File.realpath(base_dir)
-        path_real = begin
-          File.realpath(resolved_path)
+        def parse_dotenv_file(path, file_label:, value_key:, value_transform: method(:stringify_value))
+          File.read(path).each_line.each_with_object([]) do |line, entries|
+            line = line.strip
+            next if line.blank? || line.start_with?('#')
+
+            name, value = line.split('=', 2)
+            name = name.strip
+            raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank? || value.nil?
+
+            entries << build_entry(name, strip_wrapping_quotes(strip_inline_comment(value.to_s).strip), value_key:, value_transform:)
+          end
+        end
+
+        private
+
+        def valid_yaml_array_entry?(entry, value_key)
+          return false unless entry.is_a?(Hash)
+
+          string_keys = ['name', value_key.to_s]
+          symbol_keys = [:name, value_key]
+
+          same_keys?(entry.keys, string_keys) || same_keys?(entry.keys, symbol_keys)
+        end
+
+        def same_keys?(actual_keys, expected_keys)
+          (actual_keys - expected_keys).empty? && (expected_keys - actual_keys).empty?
+        end
+
+        def stringify_value(value)
+          value.is_a?(String) ? value : value.to_s
+        end
+
+        def build_entry(name, value, value_key:, value_transform:)
+          raise Exceptions::ValidationError, 'Entry name must be present.' if name.nil?
+
+          normalized_name = name.to_s
+          raise Exceptions::ValidationError, 'Entry name must be present.' if normalized_name.strip.empty?
+
+          {
+            name: normalized_name,
+            value_key => value_transform.call(value)
+          }
+        end
+
+        def invalid_entry_message(entry_label, entry, container_identifier)
+          sanitized_entry = sanitize_entry_for_message(entry)
+
+          if container_identifier.present?
+            "Invalid #{entry_label} entry for container override '#{container_identifier}'. [#{sanitized_entry}]"
+          else
+            "Invalid #{entry_label} entry. [#{sanitized_entry}]"
+          end
+        end
+
+        def sanitize_entry_for_message(entry)
+          return "Hash(size: #{entry.size}, keys: #{entry.keys.inspect})" if entry.is_a?(Hash)
+          return "Array(size: #{entry.size})" if entry.is_a?(Array)
+          return "String(size: #{entry.size})" if entry.is_a?(String)
+
+          entry.inspect
+        end
+
+        def strip_inline_comment(value)
+          in_single_quote = false
+          in_double_quote = false
+
+          value.each_char.with_index do |char, i|
+            case char
+            when "'"
+              in_single_quote = !in_single_quote unless in_double_quote
+            when '"'
+              in_double_quote = !in_double_quote unless in_single_quote
+            when '#'
+              return value[0, i] if inline_comment_start?(value, i, in_single_quote, in_double_quote)
+            end
+          end
+
+          value
+        end
+
+        def inline_comment_start?(value, index, in_single_quote, in_double_quote)
+          return false if in_single_quote || in_double_quote
+
+          index.zero? || value[index - 1].match?(/\s/)
+        end
+
+        def strip_wrapping_quotes(value)
+          return value unless value.length >= 2
+          return value[1..-2] if value.start_with?('"') && value.end_with?('"')
+          return value[1..-2] if value.start_with?("'") && value.end_with?("'")
+
+          value
+        end
+
+        def validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
+          base_real = realpath_or_expand(base_dir)
+          path_real = realpath_or_expand(resolved_path)
+
+          return if path_real == base_real || path_real.start_with?(base_real + File::SEPARATOR)
+
+          raise Exceptions::ValidationError,
+                "#{file_label.capitalize} file path for container override '#{container_identifier}' is outside the base directory. [#{resolved_path}]"
+        end
+
+        def realpath_or_expand(path)
+          File.realpath(path)
         rescue Errno::ENOENT
-          resolved_path
+          File.expand_path(path)
         end
-
-        return if path_real == base_real || path_real.start_with?(base_real + File::SEPARATOR)
-
-        raise Exceptions::ValidationError,
-              "#{file_label.capitalize} file path for container override '#{container_identifier}' is outside the base directory. [#{resolved_path}]"
       end
-      private_class_method :validate_within_base_dir!
     end
   end
 end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -132,7 +132,7 @@ module Genova
           name = name.strip
           raise Exceptions::ValidationError, "Invalid #{file_label} line. [#{path}]" if name.blank?
 
-          entries << build_entry(name, strip_wrapping_quotes(value.to_s.strip), value_key:, value_transform:)
+          entries << build_entry(name, strip_wrapping_quotes(strip_inline_comment(value.to_s).strip), value_key:, value_transform:)
         end
       end
 
@@ -156,6 +156,25 @@ module Genova
         end
       end
       private_class_method :invalid_entry_message
+
+      def strip_inline_comment(value)
+        in_single_quote = false
+        in_double_quote = false
+
+        value.each_char.with_index do |char, i|
+          case char
+          when "'"
+            in_single_quote = !in_single_quote unless in_double_quote
+          when '"'
+            in_double_quote = !in_double_quote unless in_single_quote
+          when '#'
+            return value[0, i] unless in_single_quote || in_double_quote
+          end
+        end
+
+        value
+      end
+      private_class_method :strip_inline_comment
 
       def strip_wrapping_quotes(value)
         return value unless value.length >= 2

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -68,6 +68,7 @@ module Genova
           end
 
           resolved_path = File.expand_path(file_path, base_dir)
+          validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
           current_entries = read_file(
             resolved_path,
             file_label:,
@@ -158,6 +159,21 @@ module Genova
         value
       end
       private_class_method :strip_wrapping_quotes
+
+      def validate_within_base_dir!(resolved_path, base_dir, file_label, container_identifier)
+        base_real = File.realpath(base_dir)
+        path_real = begin
+          File.realpath(resolved_path)
+        rescue Errno::ENOENT
+          resolved_path
+        end
+
+        return if path_real == base_real || path_real.start_with?(base_real + File::SEPARATOR)
+
+        raise Exceptions::ValidationError,
+              "#{file_label.capitalize} file path for container override '#{container_identifier}' is outside the base directory. [#{resolved_path}]"
+      end
+      private_class_method :validate_within_base_dir!
     end
   end
 end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -41,7 +41,13 @@ module Genova
           end
 
           entry_hash = entry.deep_symbolize_keys
-          if entry_hash.keys.sort == [:name, value_key].sort
+          canonical_keys = %i[name value value_from]
+
+          if (entry_hash.keys & canonical_keys).any?
+            unless entry_hash.keys.sort == [:name, value_key].sort
+              raise Exceptions::ValidationError, invalid_entry_message(entry_label, entry, container_identifier)
+            end
+
             normalized << build_entry(entry_hash[:name], entry_hash[value_key], value_key:, value_transform:)
             next
           end

--- a/lib/autoloads/genova/ecs/named_entries.rb
+++ b/lib/autoloads/genova/ecs/named_entries.rb
@@ -104,9 +104,10 @@ module Genova
           yaml.map do |entry|
             raise Exceptions::ValidationError, "Invalid #{entry_label} entry. [#{path}]" unless valid_yaml_array_entry?(entry, value_key)
 
+            entry_hash = entry.deep_symbolize_keys
             build_entry(
-              entry.key?('name') ? entry['name'] : entry[:name],
-              entry.key?(value_key.to_s) ? entry[value_key.to_s] : entry[value_key],
+              entry_hash[:name],
+              entry_hash[value_key],
               value_key:,
               value_transform:
             )
@@ -119,17 +120,17 @@ module Genova
       def valid_yaml_array_entry?(entry, value_key)
         return false unless entry.is_a?(Hash)
 
-        has_string_keys = entry.key?('name') && entry.key?(value_key.to_s)
-        has_symbol_keys = entry.key?(:name) && entry.key?(value_key)
+        string_keys = ['name', value_key.to_s]
+        symbol_keys = [:name, value_key]
 
-        (entry.keys - allowed_yaml_array_entry_keys(value_key)).empty? && (has_string_keys || has_symbol_keys)
+        same_keys?(entry.keys, string_keys) || same_keys?(entry.keys, symbol_keys)
       end
       private_class_method :valid_yaml_array_entry?
 
-      def allowed_yaml_array_entry_keys(value_key)
-        ['name', value_key.to_s, :name, value_key]
+      def same_keys?(actual_keys, expected_keys)
+        (actual_keys - expected_keys).empty? && (expected_keys - actual_keys).empty?
       end
-      private_class_method :allowed_yaml_array_entry_keys
+      private_class_method :same_keys?
 
       def parse_dotenv_file(path, file_label:, value_key:, value_transform: method(:stringify_value))
         File.read(path).each_line.each_with_object([]) do |line, entries|

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -74,30 +74,9 @@ module Genova
             reset_array!(task_definition, task_overrides, :container_definitions, index, :linux_parameters, :capabilities, :add)
             reset_array!(task_definition, task_overrides, :container_definitions, index, :linux_parameters, :capabilities, :drop)
 
-            merged_named_entries = merged_container_named_entries(container_definition, override_container_definition)
-            container_definition.deeper_merge!(override_container_definition.except(*merged_named_entries.keys))
-            apply_merged_container_named_entries!(container_definition, merged_named_entries)
-          end
-        end
-
-        def merged_container_named_entries(container_definition, override_container_definition)
-          %i[environment secrets].each_with_object({}) do |entry_key, merged_entries|
-            next unless override_container_definition[entry_key].present?
-
-            merged_entries[entry_key] = Ecs::NamedEntries.merge(
-              container_definition[entry_key],
-              override_container_definition[entry_key]
-            )
-          end
-        end
-
-        def apply_merged_container_named_entries!(container_definition, merged_named_entries)
-          merged_named_entries.each do |entry_key, entries|
-            if entries.present?
-              container_definition[entry_key] = entries
-            else
-              container_definition.delete(entry_key)
-            end
+            merged = Ecs::NamedEntries.merge_container_entries(container_definition, override_container_definition)
+            container_definition.deeper_merge!(override_container_definition.except(*merged.keys))
+            Ecs::NamedEntries.assign_container_entries!(container_definition, merged)
           end
         end
 

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -75,6 +75,7 @@ module Genova
             reset_array!(task_definition, task_overrides, :container_definitions, index, :linux_parameters, :capabilities, :drop)
 
             merge_container_environment!(container_definition, override_container_definition)
+            merge_container_secrets!(container_definition, override_container_definition)
             container_definition.deeper_merge!(override_container_definition)
           end
         end
@@ -84,6 +85,14 @@ module Genova
 
           override_container_definition[:environment].each do |environment|
             container_definition[:environment].delete_if { |k, _v| k[:name] == environment[:name] }
+          end
+        end
+
+        def merge_container_secrets!(container_definition, override_container_definition)
+          return unless container_definition[:secrets].present? && override_container_definition[:secrets].present?
+
+          override_container_definition[:secrets].each do |secret|
+            container_definition[:secrets].delete_if { |k, _v| k[:name] == secret[:name] }
           end
         end
 

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -60,7 +60,7 @@ module Genova
 
         def override_container_definitions!(task_definition, task_overrides)
           (task_overrides[:container_definitions] || []).each_with_index do |override_container_definition, index|
-            container_definition = task_definition[:container_definitions].find { |k, _v| k[:name] == override_container_definition[:name] }
+            container_definition = task_definition[:container_definitions].find { |k| k[:name] == override_container_definition[:name] }
 
             next unless container_definition.present?
 
@@ -84,7 +84,7 @@ module Genova
           return unless container_definition[:environment].present? && override_container_definition[:environment].present?
 
           override_container_definition[:environment].each do |environment|
-            container_definition[:environment].delete_if { |k, _v| k[:name] == environment[:name] }
+            container_definition[:environment].delete_if { |current_environment| current_environment[:name] == environment[:name] }
           end
         end
 
@@ -92,7 +92,7 @@ module Genova
           return unless container_definition[:secrets].present? && override_container_definition[:secrets].present?
 
           override_container_definition[:secrets].each do |secret|
-            container_definition[:secrets].delete_if { |k, _v| k[:name] == secret[:name] }
+            container_definition[:secrets].delete_if { |current_secret| current_secret[:name] == secret[:name] }
           end
         end
 

--- a/lib/autoloads/genova/ecs/task/client.rb
+++ b/lib/autoloads/genova/ecs/task/client.rb
@@ -74,25 +74,30 @@ module Genova
             reset_array!(task_definition, task_overrides, :container_definitions, index, :linux_parameters, :capabilities, :add)
             reset_array!(task_definition, task_overrides, :container_definitions, index, :linux_parameters, :capabilities, :drop)
 
-            merge_container_environment!(container_definition, override_container_definition)
-            merge_container_secrets!(container_definition, override_container_definition)
-            container_definition.deeper_merge!(override_container_definition)
+            merged_named_entries = merged_container_named_entries(container_definition, override_container_definition)
+            container_definition.deeper_merge!(override_container_definition.except(*merged_named_entries.keys))
+            apply_merged_container_named_entries!(container_definition, merged_named_entries)
           end
         end
 
-        def merge_container_environment!(container_definition, override_container_definition)
-          return unless container_definition[:environment].present? && override_container_definition[:environment].present?
+        def merged_container_named_entries(container_definition, override_container_definition)
+          %i[environment secrets].each_with_object({}) do |entry_key, merged_entries|
+            next unless override_container_definition[entry_key].present?
 
-          override_container_definition[:environment].each do |environment|
-            container_definition[:environment].delete_if { |current_environment| current_environment[:name] == environment[:name] }
+            merged_entries[entry_key] = Ecs::NamedEntries.merge(
+              container_definition[entry_key],
+              override_container_definition[entry_key]
+            )
           end
         end
 
-        def merge_container_secrets!(container_definition, override_container_definition)
-          return unless container_definition[:secrets].present? && override_container_definition[:secrets].present?
-
-          override_container_definition[:secrets].each do |secret|
-            container_definition[:secrets].delete_if { |current_secret| current_secret[:name] == secret[:name] }
+        def apply_merged_container_named_entries!(container_definition, merged_named_entries)
+          merged_named_entries.each do |entry_key, entries|
+            if entries.present?
+              container_definition[entry_key] = entries
+            else
+              container_definition.delete(entry_key)
+            end
           end
         end
 

--- a/spec/lib/autoloads/genova/docker/client_spec.rb
+++ b/spec/lib/autoloads/genova/docker/client_spec.rb
@@ -95,7 +95,8 @@ module Genova
                           '-t web:latest ' +
                           "-f #{Rails.root}/config/Dockerfile " +
                           '--label com.metaps.genova.build_key=\\w{8} ' +
-                          "--build-arg FOO='SecretStringType' --build-arg BAR='PSParameterValue' --build-arg BAZ='PSParameterValue' "
+                          "--build-arg FOO='SecretStringType' --build-arg BAR='PSParameterValue' --build-arg BAZ='PSParameterValue' " +
+                          "#{Rails.root}/config"
 
                 expect(command).to match(pattern)
               end

--- a/spec/lib/autoloads/genova/docker/client_spec.rb
+++ b/spec/lib/autoloads/genova/docker/client_spec.rb
@@ -19,12 +19,12 @@ module Genova
         end
 
         context 'when build is string' do
-          let(:container_config) {
+          let(:container_config) do
             {
               name: 'web',
               build: '.'
             }
-          }
+          end
 
           it 'should return docker build time' do
             expect(docker_client.build_image(container_config, 'web')).to eq(0.0)
@@ -36,10 +36,10 @@ module Genova
 
             expect(Genova::Command::Executor).to have_received(:call) do |command, _, _|
               pattern = 'docker build ' +
-                '-t web:latest ' +
-                "-f #{Rails.root}/config/Dockerfile " +
-                '--label com.metaps.genova.build_key=\\w{8} ' +
-                "--no-cache #{Rails.root}/config"
+                        '-t web:latest ' +
+                        "-f #{Rails.root}/config/Dockerfile " +
+                        '--label com.metaps.genova.build_key=\\w{8} ' +
+                        "--no-cache #{Rails.root}/config"
 
               expect(command).to match(pattern)
             end
@@ -48,7 +48,7 @@ module Genova
 
         context 'when build is hash' do
           context 'when args is specified' do
-            let(:container_config) {
+            let(:container_config) do
               {
                 name: 'web',
                 build: {
@@ -59,7 +59,7 @@ module Genova
                   }
                 }
               }
-            }
+            end
 
             it 'should return docker build time' do
               allow(cipher).to receive(:encrypt_format?).and_return(true, false)
@@ -70,7 +70,7 @@ module Genova
           end
 
           context 'when secret_args is specified' do
-            let(:container_config) {
+            let(:container_config) do
               {
                 name: 'web',
                 build: {
@@ -85,18 +85,17 @@ module Genova
                   }
                 }
               }
-            }
+            end
 
             it 'should return valid command' do
               docker_client.build_image(container_config, 'web')
 
               expect(Genova::Command::Executor).to have_received(:call) do |command, _, _|
                 pattern = 'docker build ' +
-                    '-t web:latest ' +
-                    "-f #{Rails.root}/config/Dockerfile " +
-                    '--label com.metaps.genova.build_key=\\w{8} ' +
-                    "--build-arg FOO='SecretStringType' --build-arg BAR='PSParameterValue' --build-arg BAZ='PSParameterValue' "
-                    "#{Rails.root}/config"
+                          '-t web:latest ' +
+                          "-f #{Rails.root}/config/Dockerfile " +
+                          '--label com.metaps.genova.build_key=\\w{8} ' +
+                          "--build-arg FOO='SecretStringType' --build-arg BAR='PSParameterValue' --build-arg BAZ='PSParameterValue' "
 
                 expect(command).to match(pattern)
               end

--- a/spec/lib/autoloads/genova/ecs/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/client_spec.rb
@@ -135,6 +135,72 @@ module Genova
 
             expect { client.deploy_service }.to_not raise_error
           end
+
+          it 'resolves environment_from_files in container_overrides and applies them to task_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/app.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/app.env').and_return("DOTENV_KEY=dotenv\nFILE_OVERRIDE=dotenv\nSHARED_KEY=dotenv\n")
+            allow(File).to receive(:read).with('/repo/config/shared.yml').and_return(
+              {
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => 1,
+                'SHARED_KEY' => 'yaml'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_service).and_return(
+              path: 'service.yml',
+              containers: [
+                name: 'web'
+              ],
+              task_overrides: {
+                container_definitions: [
+                  {
+                    name: 'web',
+                    environment: [
+                      { name: 'EXISTING_ONLY', value: 'existing' },
+                      { name: 'SHARED_KEY', value: 'task_override' }
+                    ]
+                  }
+                ]
+              },
+              container_overrides: [
+                {
+                  name: 'web',
+                  command: %w[bundle exec puma],
+                  environment_from_files: [
+                    './app.env',
+                    './shared.yml'
+                  ],
+                  environment: [
+                    { 'INLINE_ONLY' => 'inline' },
+                    { 'SHARED_KEY' => 'inline_override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(task_client).to receive(:register) do |_task_definition_path, task_overrides, tag:|
+              expect(tag).to eq(deploy_job.label)
+              expect(task_overrides[:container_definitions][0][:command]).to eq(%w[bundle exec puma])
+              expect(
+                task_overrides[:container_definitions][0][:environment].to_h { |environment| [environment[:name], environment[:value]] }
+              ).to eq(
+                'EXISTING_ONLY' => 'existing',
+                'DOTENV_KEY' => 'dotenv',
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => '1',
+                'INLINE_ONLY' => 'inline',
+                'SHARED_KEY' => 'inline_override'
+              )
+              task_definition
+            end
+            allow(service_client).to receive(:update)
+            allow(service_client).to receive(:exist?).and_return(true)
+            allow(Ecs::Deployer::Service::Client).to receive(:new).and_return(service_client)
+
+            expect { client.deploy_service }.to_not raise_error
+          end
         end
 
         describe 'deploy_scheduled_task' do

--- a/spec/lib/autoloads/genova/ecs/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/client_spec.rb
@@ -33,6 +33,7 @@ module Genova
 
           allow(code_manager).to receive(:deploy_config).and_return(deploy_config)
           allow(code_manager).to receive(:task_definition_config_path).and_return('task_definition_path')
+          allow(code_manager).to receive(:base_path).and_return('/repo')
           allow(code_manager).to receive(:update)
           allow(code_manager).to receive(:update_submodule)
           allow(CodeManager::Git).to receive(:new).and_return(code_manager)
@@ -69,6 +70,54 @@ module Genova
 
             expect { client.deploy_run_task }.to_not raise_error
           end
+
+          it 'resolves environment_from_files in container_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/app.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/app.env').and_return("DOTENV_KEY=dotenv\nFILE_OVERRIDE=dotenv\nSHARED_KEY=dotenv\n")
+            allow(File).to receive(:read).with('/repo/config/shared.yml').and_return(
+              {
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => 1,
+                'SHARED_KEY' => 'yaml'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_run_task).and_return(
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ],
+              container_overrides: [
+                {
+                  name: 'web',
+                  environment_from_files: [
+                    './app.env',
+                    './shared.yml'
+                  ],
+                  environment: [
+                    { 'INLINE_ONLY' => 'inline' },
+                    { 'SHARED_KEY' => 'inline_override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(run_task_client).to receive(:execute) do |_task_definition_arn, options|
+              expect(
+                options[:container_overrides][0][:environment].to_h { |environment| [environment[:name], environment[:value]] }
+              ).to eq(
+                'DOTENV_KEY' => 'dotenv',
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => '1',
+                'INLINE_ONLY' => 'inline',
+                'SHARED_KEY' => 'inline_override'
+              )
+            end
+            allow(Ecs::Deployer::RunTask::Client).to receive(:new).and_return(run_task_client)
+
+            expect { client.deploy_run_task }.to_not raise_error
+          end
         end
 
         describe 'deploy_service' do
@@ -85,6 +134,70 @@ module Genova
             allow(Ecs::Deployer::Service::Client).to receive(:new).and_return(service_client)
 
             expect { client.deploy_service }.to_not raise_error
+          end
+        end
+
+        describe 'deploy_scheduled_task' do
+          let(:scheduled_task_client) { double(Ecs::Deployer::ScheduledTask::Client) }
+
+          it 'resolves environment_from_files in container_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/app.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/app.env').and_return("DOTENV_KEY=dotenv\nFILE_OVERRIDE=dotenv\nSHARED_KEY=dotenv\n")
+            allow(File).to receive(:read).with('/repo/config/shared.yml').and_return(
+              {
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => 1,
+                'SHARED_KEY' => 'yaml'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_scheduled_task_rule).and_return(
+              rule: 'nightly',
+              expression: 'cron(0 0 * * ? *)',
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ]
+            )
+            allow(deploy_config).to receive(:find_scheduled_task_target).and_return(
+              name: 'job',
+              path: 'task.yml',
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ],
+              container_overrides: [
+                {
+                  name: 'web',
+                  environment_from_files: [
+                    './app.env',
+                    './shared.yml'
+                  ],
+                  environment: [
+                    { 'INLINE_ONLY' => 'inline' },
+                    { 'SHARED_KEY' => 'inline_override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(Ecs::Deployer::ScheduledTask::Target).to receive(:build) do |_deploy_job, _task_definition_arn, target_config, _logger|
+              expect(
+                target_config[:container_overrides][0][:environment].to_h { |environment| [environment[:name], environment[:value]] }
+              ).to eq(
+                'DOTENV_KEY' => 'dotenv',
+                'FILE_OVERRIDE' => 'yaml',
+                'YAML_KEY' => '1',
+                'INLINE_ONLY' => 'inline',
+                'SHARED_KEY' => 'inline_override'
+              )
+              { ecs_parameters: { task_definition_arn: 'task_definition_arn' } }
+            end
+            allow(scheduled_task_client).to receive(:update)
+            allow(Ecs::Deployer::ScheduledTask::Client).to receive(:new).and_return(scheduled_task_client)
+
+            expect { client.deploy_scheduled_task }.to_not raise_error
           end
         end
       end

--- a/spec/lib/autoloads/genova/ecs/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/client_spec.rb
@@ -118,6 +118,59 @@ module Genova
 
             expect { client.deploy_run_task }.to_not raise_error
           end
+
+          it 'resolves secrets_from_files in container_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/secrets.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared-secrets.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/secrets.env').and_return("DOTENV_SECRET=/dotenv\nFILE_OVERRIDE=/dotenv-override\nSHARED_SECRET=/dotenv-shared\n")
+            allow(File).to receive(:read).with('/repo/config/shared-secrets.yml').and_return(
+              {
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'SHARED_SECRET' => '/yaml-shared'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_run_task).and_return(
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ],
+              container_overrides: [
+                {
+                  name: 'web',
+                  secrets_from_files: [
+                    './secrets.env',
+                    './shared-secrets.yml'
+                  ],
+                  secrets: [
+                    { 'INLINE_SECRET' => '/inline' },
+                    { 'SHARED_SECRET' => '/inline-override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(task_client).to receive(:register) do |_task_definition_path, task_overrides, tag:|
+              expect(tag).to eq(deploy_job.label)
+              expect(
+                task_overrides[:container_definitions][0][:secrets].to_h { |secret| [secret[:name], secret[:value_from]] }
+              ).to eq(
+                'DOTENV_SECRET' => '/dotenv',
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'INLINE_SECRET' => '/inline',
+                'SHARED_SECRET' => '/inline-override'
+              )
+              task_definition
+            end
+            expect(run_task_client).to receive(:execute) do |_task_definition_arn, options|
+              expect(options[:container_overrides]).to eq([])
+            end
+            allow(Ecs::Deployer::RunTask::Client).to receive(:new).and_return(run_task_client)
+
+            expect { client.deploy_run_task }.to_not raise_error
+          end
         end
 
         describe 'deploy_service' do
@@ -201,6 +254,70 @@ module Genova
 
             expect { client.deploy_service }.to_not raise_error
           end
+
+          it 'resolves secrets_from_files in container_overrides and applies them to task_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/secrets.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared-secrets.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/secrets.env').and_return("DOTENV_SECRET=/dotenv\nFILE_OVERRIDE=/dotenv-override\nSHARED_SECRET=/dotenv-shared\n")
+            allow(File).to receive(:read).with('/repo/config/shared-secrets.yml').and_return(
+              {
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'SHARED_SECRET' => '/yaml-shared'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_service).and_return(
+              path: 'service.yml',
+              containers: [
+                name: 'web'
+              ],
+              task_overrides: {
+                container_definitions: [
+                  {
+                    name: 'web',
+                    secrets: [
+                      { name: 'EXISTING_SECRET', value_from: '/existing' },
+                      { name: 'SHARED_SECRET', value_from: '/task-override' }
+                    ]
+                  }
+                ]
+              },
+              container_overrides: [
+                {
+                  name: 'web',
+                  secrets_from_files: [
+                    './secrets.env',
+                    './shared-secrets.yml'
+                  ],
+                  secrets: [
+                    { 'INLINE_SECRET' => '/inline' },
+                    { 'SHARED_SECRET' => '/inline-override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(task_client).to receive(:register) do |_task_definition_path, task_overrides, tag:|
+              expect(tag).to eq(deploy_job.label)
+              expect(
+                task_overrides[:container_definitions][0][:secrets].to_h { |secret| [secret[:name], secret[:value_from]] }
+              ).to eq(
+                'EXISTING_SECRET' => '/existing',
+                'DOTENV_SECRET' => '/dotenv',
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'INLINE_SECRET' => '/inline',
+                'SHARED_SECRET' => '/inline-override'
+              )
+              task_definition
+            end
+            allow(service_client).to receive(:update)
+            allow(service_client).to receive(:exist?).and_return(true)
+            allow(Ecs::Deployer::Service::Client).to receive(:new).and_return(service_client)
+
+            expect { client.deploy_service }.to_not raise_error
+          end
         end
 
         describe 'deploy_scheduled_task' do
@@ -257,6 +374,80 @@ module Genova
                 'YAML_KEY' => '1',
                 'INLINE_ONLY' => 'inline',
                 'SHARED_KEY' => 'inline_override'
+              )
+              { ecs_parameters: { task_definition_arn: 'task_definition_arn' } }
+            end
+            allow(scheduled_task_client).to receive(:update)
+            allow(Ecs::Deployer::ScheduledTask::Client).to receive(:new).and_return(scheduled_task_client)
+
+            expect { client.deploy_scheduled_task }.to_not raise_error
+          end
+
+          it 'resolves secrets_from_files in container_overrides' do
+            allow(File).to receive(:file?).with('/repo/config/secrets.env').and_return(true)
+            allow(File).to receive(:file?).with('/repo/config/shared-secrets.yml').and_return(true)
+            allow(File).to receive(:read).with('/repo/config/secrets.env').and_return("DOTENV_SECRET=/dotenv\nFILE_OVERRIDE=/dotenv-override\nSHARED_SECRET=/dotenv-shared\n")
+            allow(File).to receive(:read).with('/repo/config/shared-secrets.yml').and_return(
+              {
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'SHARED_SECRET' => '/yaml-shared'
+              }.to_yaml
+            )
+
+            allow(deploy_config).to receive(:find_scheduled_task_rule).and_return(
+              rule: 'nightly',
+              expression: 'cron(0 0 * * ? *)',
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ]
+            )
+            allow(deploy_config).to receive(:find_scheduled_task_target).and_return(
+              name: 'job',
+              path: 'task.yml',
+              containers: [
+                name: 'web',
+                image: ' xxx.dkr.ecr.ap-northeast-1.amazonaws.com/xxx:latest'
+              ],
+              container_overrides: [
+                {
+                  name: 'web',
+                  secrets_from_files: [
+                    './secrets.env',
+                    './shared-secrets.yml'
+                  ],
+                  secrets: [
+                    { 'INLINE_SECRET' => '/inline' },
+                    { 'SHARED_SECRET' => '/inline-override' }
+                  ]
+                }
+              ]
+            )
+
+            expect(task_client).to receive(:register) do |_task_definition_path, task_overrides, tag:|
+              expect(tag).to eq(deploy_job.label)
+              expect(
+                task_overrides[:container_definitions][0][:secrets].to_h { |secret| [secret[:name], secret[:value_from]] }
+              ).to eq(
+                'DOTENV_SECRET' => '/dotenv',
+                'FILE_OVERRIDE' => '/yaml-override',
+                'YAML_SECRET' => '/yaml',
+                'INLINE_SECRET' => '/inline',
+                'SHARED_SECRET' => '/inline-override'
+              )
+              task_definition
+            end
+            expect(Ecs::Deployer::ScheduledTask::Target).to receive(:build) do |_deploy_job, _task_definition_arn, target_config, _logger|
+              expect(target_config[:container_overrides][0]).to eq(
+                name: 'web',
+                secrets: [
+                  { name: 'DOTENV_SECRET', value_from: '/dotenv' },
+                  { name: 'FILE_OVERRIDE', value_from: '/yaml-override' },
+                  { name: 'YAML_SECRET', value_from: '/yaml' },
+                  { name: 'INLINE_SECRET', value_from: '/inline' },
+                  { name: 'SHARED_SECRET', value_from: '/inline-override' }
+                ]
               )
               { ecs_parameters: { task_definition_arn: 'task_definition_arn' } }
             end

--- a/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
@@ -52,6 +52,29 @@ module Genova
           )
         end
 
+        it 'strips whitespace around name/value and handles quoted values in dotenv files' do
+          env_file_path = '/repo/config/app.env'
+
+          allow(File).to receive(:file?).with(env_file_path).and_return(true)
+          allow(File).to receive(:read).with(env_file_path).and_return(
+            "PLAIN=value\nDOUBLE_QUOTED=\"quoted value\"\nSINGLE_QUOTED='single quoted'\nSPACED = spaced value\n"
+          )
+
+          container_overrides = described_class.build(
+            [{ name: 'app', environment_from_files: ['./app.env'] }],
+            base_dir:
+          )
+
+          expect(
+            container_overrides[0][:environment].to_h { |e| [e[:name], e[:value]] }
+          ).to eq(
+            'PLAIN' => 'value',
+            'DOUBLE_QUOTED' => 'quoted value',
+            'SINGLE_QUOTED' => 'single quoted',
+            'SPACED' => 'spaced value'
+          )
+        end
+
         it 'raises error when environment file path is invalid' do
           expect do
             described_class.build(

--- a/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+module Genova
+  module Ecs
+    describe ContainerOverrideBuilder do
+      describe 'build' do
+        let(:base_dir) { '/repo/config' }
+
+        it 'loads environment from files and allows inline environment to override it' do
+          env_file_path = '/repo/config/app.env'
+          yaml_file_path = '/repo/config/shared.yml'
+
+          allow(File).to receive(:file?).with(env_file_path).and_return(true)
+          allow(File).to receive(:file?).with(yaml_file_path).and_return(true)
+          allow(File).to receive(:read).with(env_file_path).and_return("DOTENV_KEY=dotenv\nFILE_OVERRIDE=dotenv\nSHARED_KEY=dotenv\n")
+          allow(File).to receive(:read).with(yaml_file_path).and_return(
+            {
+              'YAML_KEY' => 1,
+              'FILE_OVERRIDE' => 'yaml',
+              'SHARED_KEY' => 'yaml'
+            }.to_yaml
+          )
+
+          container_overrides = described_class.build(
+            [
+              {
+                name: 'app',
+                command: %w[bundle exec rake],
+                environment_from_files: [
+                  './app.env',
+                  './shared.yml'
+                ],
+                environment: [
+                  { 'INLINE_ONLY' => 'inline' },
+                  { 'SHARED_KEY' => 'inline_override' }
+                ]
+              }
+            ],
+            base_dir:
+          )
+
+          expect(container_overrides[0][:name]).to eq('app')
+          expect(container_overrides[0][:command]).to eq(%w[bundle exec rake])
+          expect(
+            container_overrides[0][:environment].to_h { |environment| [environment[:name], environment[:value]] }
+          ).to eq(
+            'DOTENV_KEY' => 'dotenv',
+            'FILE_OVERRIDE' => 'yaml',
+            'YAML_KEY' => '1',
+            'INLINE_ONLY' => 'inline',
+            'SHARED_KEY' => 'inline_override'
+          )
+        end
+
+        it 'raises error when environment file path is invalid' do
+          expect do
+            described_class.build(
+              [
+                {
+                  name: 'app',
+                  environment_from_files: [nil]
+                }
+              ],
+              base_dir:
+            )
+          end.to raise_error(Exceptions::ValidationError, "Invalid environment file path for container override 'app'. [nil]")
+        end
+
+        it 'raises error when environment file does not exist' do
+          allow(File).to receive(:file?).with('/repo/config/missing.env').and_return(false)
+
+          expect do
+            described_class.build(
+              [
+                {
+                  name: 'app',
+                  environment_from_files: ['./missing.env']
+                }
+              ],
+              base_dir:
+            )
+          end.to raise_error(Exceptions::ValidationError, 'Environment file does not exist. [/repo/config/missing.env]')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
@@ -52,6 +52,49 @@ module Genova
           )
         end
 
+        it 'loads secrets from files and allows inline secrets to override it' do
+          env_file_path = '/repo/config/secrets.env'
+          yaml_file_path = '/repo/config/shared-secrets.yml'
+
+          allow(File).to receive(:file?).with(env_file_path).and_return(true)
+          allow(File).to receive(:file?).with(yaml_file_path).and_return(true)
+          allow(File).to receive(:read).with(env_file_path).and_return("DOTENV_SECRET=/dotenv\nFILE_OVERRIDE=/dotenv-override\nSHARED_SECRET=/dotenv-shared\n")
+          allow(File).to receive(:read).with(yaml_file_path).and_return(
+            {
+              'YAML_SECRET' => '/yaml',
+              'FILE_OVERRIDE' => '/yaml-override',
+              'SHARED_SECRET' => '/yaml-shared'
+            }.to_yaml
+          )
+
+          container_overrides = described_class.build(
+            [
+              {
+                name: 'app',
+                secrets_from_files: [
+                  './secrets.env',
+                  './shared-secrets.yml'
+                ],
+                secrets: [
+                  { 'INLINE_SECRET' => '/inline' },
+                  { 'SHARED_SECRET' => '/inline-override' }
+                ]
+              }
+            ],
+            base_dir:
+          )
+
+          expect(
+            container_overrides[0][:secrets].to_h { |secret| [secret[:name], secret[:value_from]] }
+          ).to eq(
+            'DOTENV_SECRET' => '/dotenv',
+            'FILE_OVERRIDE' => '/yaml-override',
+            'YAML_SECRET' => '/yaml',
+            'INLINE_SECRET' => '/inline',
+            'SHARED_SECRET' => '/inline-override'
+          )
+        end
+
         it 'strips whitespace around name/value and handles quoted values in dotenv files' do
           env_file_path = '/repo/config/app.env'
 
@@ -72,6 +115,29 @@ module Genova
             'DOUBLE_QUOTED' => 'quoted value',
             'SINGLE_QUOTED' => 'single quoted',
             'SPACED' => 'spaced value'
+          )
+        end
+
+        it 'strips whitespace around name/value_from and handles quoted values in secrets dotenv files' do
+          env_file_path = '/repo/config/secrets.env'
+
+          allow(File).to receive(:file?).with(env_file_path).and_return(true)
+          allow(File).to receive(:read).with(env_file_path).and_return(
+            "PLAIN=/path/plain\nDOUBLE_QUOTED=\"/path/quoted value\"\nSINGLE_QUOTED='/path/single quoted'\nSPACED = /path/spaced value\n"
+          )
+
+          container_overrides = described_class.build(
+            [{ name: 'app', secrets_from_files: ['./secrets.env'] }],
+            base_dir:
+          )
+
+          expect(
+            container_overrides[0][:secrets].to_h { |secret| [secret[:name], secret[:value_from]] }
+          ).to eq(
+            'PLAIN' => '/path/plain',
+            'DOUBLE_QUOTED' => '/path/quoted value',
+            'SINGLE_QUOTED' => '/path/single quoted',
+            'SPACED' => '/path/spaced value'
           )
         end
 
@@ -103,6 +169,36 @@ module Genova
               base_dir:
             )
           end.to raise_error(Exceptions::ValidationError, 'Environment file does not exist. [/repo/config/missing.env]')
+        end
+
+        it 'raises error when secrets file path is invalid' do
+          expect do
+            described_class.build(
+              [
+                {
+                  name: 'app',
+                  secrets_from_files: [nil]
+                }
+              ],
+              base_dir:
+            )
+          end.to raise_error(Exceptions::ValidationError, "Invalid secrets file path for container override 'app'. [nil]")
+        end
+
+        it 'raises error when secrets file does not exist' do
+          allow(File).to receive(:file?).with('/repo/config/missing-secrets.env').and_return(false)
+
+          expect do
+            described_class.build(
+              [
+                {
+                  name: 'app',
+                  secrets_from_files: ['./missing-secrets.env']
+                }
+              ],
+              base_dir:
+            )
+          end.to raise_error(Exceptions::ValidationError, 'Secrets file does not exist. [/repo/config/missing-secrets.env]')
         end
       end
     end

--- a/spec/lib/autoloads/genova/ecs/named_entries_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/named_entries_spec.rb
@@ -47,6 +47,21 @@ module Genova
             )
           end.to raise_error(Exceptions::ValidationError, "Invalid environment entry. [#{path}]")
         end
+
+        it 'rejects array entries with mixed key styles' do
+          path = '/repo/config/app.yml'
+          allow(File).to receive(:read).with(path).and_return('yaml')
+          allow(YAML).to receive(:safe_load).and_return([{ 'name' => 'FOO', value: '1' }])
+
+          expect do
+            described_class.parse_yaml_file(
+              path,
+              file_label: 'environment',
+              entry_label: 'environment',
+              value_key: :value
+            )
+          end.to raise_error(Exceptions::ValidationError, "Invalid environment entry. [#{path}]")
+        end
       end
 
       describe '.parse_dotenv_file' do

--- a/spec/lib/autoloads/genova/ecs/named_entries_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/named_entries_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+module Genova
+  module Ecs
+    describe NamedEntries do
+      describe '.normalize' do
+        it 'rejects blank entry names before normalization' do
+          expect do
+            described_class.normalize(
+              [{ name: ' ', value: '1' }],
+              value_key: :value,
+              entry_label: 'environment'
+            )
+          end.to raise_error(Exceptions::ValidationError, 'Entry name must be present.')
+        end
+
+        it 'does not include raw hash values in invalid entry messages' do
+          expect do
+            described_class.normalize(
+              [{ name: 'PASSWORD', value: 'secret-value', unexpected: 'raw-secret' }],
+              value_key: :value,
+              entry_label: 'environment',
+              container_identifier: 'app'
+            )
+          end.to raise_error(Exceptions::ValidationError) { |error|
+            expect(error.message).to include("Invalid environment entry for container override 'app'.")
+            expect(error.message).to include('keys:')
+            expect(error.message).not_to include('secret-value')
+            expect(error.message).not_to include('raw-secret')
+          }
+        end
+      end
+
+      describe '.parse_yaml_file' do
+        it 'rejects array entries with extra keys' do
+          path = '/repo/config/app.yml'
+          allow(File).to receive(:read).with(path).and_return(
+            [{ 'name' => 'FOO', 'value' => '1', 'BAR' => '2' }].to_yaml
+          )
+
+          expect do
+            described_class.parse_yaml_file(
+              path,
+              file_label: 'environment',
+              entry_label: 'environment',
+              value_key: :value
+            )
+          end.to raise_error(Exceptions::ValidationError, "Invalid environment entry. [#{path}]")
+        end
+      end
+
+      describe '.parse_dotenv_file' do
+        it 'keeps unquoted hashes that are not preceded by whitespace' do
+          path = '/repo/config/app.env'
+          allow(File).to receive(:read).with(path).and_return("PASSWORD=abc#123\nWITH_COMMENT=value # comment\n")
+
+          entries = described_class.parse_dotenv_file(
+            path,
+            file_label: 'environment',
+            value_key: :value
+          )
+
+          expect(entries).to eq(
+            [
+              { name: 'PASSWORD', value: 'abc#123' },
+              { name: 'WITH_COMMENT', value: 'value' }
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -76,6 +76,16 @@ module Genova
                       name: 'KEY3',
                       value: 'value3'
                     }
+                  ],
+                  secrets: [
+                    {
+                      name: 'SECRET2',
+                      value_from: '/secret2_override'
+                    },
+                    {
+                      name: 'SECRET3',
+                      value_from: '/secret3'
+                    }
                   ]
                 }
               ]
@@ -93,11 +103,11 @@ module Genova
                       'date'
                     ],
                     essential: true,
-                    environment: [
-                      {
-                        name: 'KEY1',
-                        value: 'value1'
-                      },
+                  environment: [
+                    {
+                      name: 'KEY1',
+                      value: 'value1'
+                    },
                       {
                         name: 'KEY2',
                         value: 'value2_override'
@@ -105,6 +115,77 @@ module Genova
                       {
                         name: 'KEY3',
                         value: 'value3'
+                      }
+                    ],
+                    secrets: [
+                      {
+                        name: 'SECRET2',
+                        value_from: '/secret2_override'
+                      },
+                      {
+                        name: 'SECRET3',
+                        value_from: '/secret3'
+                      }
+                    ]
+                  }
+                ]
+              }
+            )
+          end
+
+          it 'overrides secrets with the same name when merging parameters' do
+            definition = {
+              container_definitions: [
+                {
+                  name: 'app',
+                  secrets: [
+                    {
+                      name: 'SECRET1',
+                      value_from: '/secret1'
+                    },
+                    {
+                      name: 'SECRET2',
+                      value_from: '/secret2'
+                    }
+                  ]
+                }
+              ]
+            }
+            overrides = {
+              container_definitions: [
+                {
+                  name: 'app',
+                  secrets: [
+                    {
+                      name: 'SECRET2',
+                      value_from: '/secret2_override'
+                    },
+                    {
+                      name: 'SECRET3',
+                      value_from: '/secret3'
+                    }
+                  ]
+                }
+              ]
+            }
+
+            expect(task_client.send(:merge_task_parameters!, definition, overrides)).to eq(
+              {
+                container_definitions: [
+                  {
+                    name: 'app',
+                    secrets: [
+                      {
+                        name: 'SECRET1',
+                        value_from: '/secret1'
+                      },
+                      {
+                        name: 'SECRET2',
+                        value_from: '/secret2_override'
+                      },
+                      {
+                        name: 'SECRET3',
+                        value_from: '/secret3'
                       }
                     ]
                   }

--- a/spec/lib/autoloads/genova/ecs/task/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/task/client_spec.rb
@@ -103,11 +103,11 @@ module Genova
                       'date'
                     ],
                     essential: true,
-                  environment: [
-                    {
-                      name: 'KEY1',
-                      value: 'value1'
-                    },
+                    environment: [
+                      {
+                        name: 'KEY1',
+                        value: 'value1'
+                      },
                       {
                         name: 'KEY2',
                         value: 'value2_override'


### PR DESCRIPTION
## wiki更新版
https://github.com/metaps/genova/wiki/Deploy-configuration
の更新版は以下
[Deploy-configuration.md](https://github.com/user-attachments/files/26318127/Deploy-configuration.md)


## 実装要約

  - container_overrides のスキーマに environment, secrets, environment_from_files, secrets_from_files が追加され、run_tasks / services / scheduled_tasks.targets で使えるようになっています。lib/autoloads/genova/config/validator/deploy_config.json:73
  - 新規の Genova::Ecs::ContainerOverrideBuilder が、config/ 配下を基準に外部ファイルを解決します。対応形式は .env / .dotenv / .yml / .yaml です。lib/autoloads/genova/ecs/container_override_builder.rb:54
  - .env は KEY=value 形式を読み、空白・コメント・引用符を吸収します。YAML は KEY: value の Hash 形式か、[{name:, value:}] / [{name:, value_from:}] の配列形式を読めます。lib/autoloads/genova/ecs/container_override_builder.rb:152
  - 優先順位は「先に読んだファイル < 後に読んだファイル < deploy.yml に直接書いた inline 値」です。同名キーは後勝ちです。lib/autoloads/genova/ecs/container_override_builder.rb:130
  - run_task / service / scheduled_task の各デプロイ前に、container_overrides を解決し、その内容を task_overrides.container_definitions にもマージするようになっています。これで secrets も task definition 側に反映されます。lib/autoloads/genova/ecs/client.rb:181
  - 実行時の ECS containerOverrides には secrets を載せず、environment と command だけを残します。つまり secrets は「実行時 override」ではなく「登録する task definition 側」に焼き込まれる設計です。これは ECS API の制約に合わせた実装だと読めます。lib/autoloads/genova/ecs/client.rb:252
  - task definition へのマージ時に、既存の environment / secrets と同名のものを先に削除してから上書きするため、重複定義が残りません。lib/autoloads/genova/ecs/task/client.rb:77
  - scheduled task では旧 overrides もまだ読めますが、container_overrides への移行を促す warning を出します。lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb:10

##  利用例
  前提として、environment_from_files / secrets_from_files の相対パスはリポジトリの config/ 基準です。lib/autoloads/genova/ecs/client.rb:191

  例1: service deploy で環境変数と secrets を外部ファイルから注入する例

```
  # config/ecs/env/common.env
  RAILS_LOG_TO_STDOUT=true
  LOG_LEVEL=info
```

```
  # config/ecs/env/production.yml
  APP_ENV: production
  LOG_LEVEL: warn
```

```
  # config/ecs/secrets/production.env
  DATABASE_URL=arn:aws:ssm:ap-northeast-1:123456789012:parameter/prod/db_url
  REDIS_URL=arn:aws:ssm:ap-northeast-1:123456789012:parameter/prod/redis_url
```
```
  # config/deploy.yml
  clusters:
    - name: prod
      services:
        web:
          path: ecs/task_definition/web.yml
          containers:
            - name: web
              image: 123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest
          container_overrides:
            - name: web
              command: ["bundle", "exec", "puma", "-C", "config/puma.rb"]
              environment_from_files:
                - ./ecs/env/common.env
                - ./ecs/env/production.yml
              secrets_from_files:
                - ./ecs/secrets/production.env
              environment:
                - LOG_LEVEL: debug
                - WEB_CONCURRENCY: 3
```
  この例だと最終的な LOG_LEVEL は debug になります。common.env の info より production.yml の warn が優先され、さらに inline の debug が最優先です。DATABASE_URL と REDIS_URL は task definition の secrets に入ります。

  例2: run task で migration 専用の環境を外部化する例

```
  clusters:
    - name: prod
      run_tasks:
        db-migrate:
          path: ecs/task_definition/app.yml
          containers:
            - name: app
              image: 123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/app:latest
          container_overrides:
            - name: app
              command: ["bundle", "exec", "rails", "db:migrate"]
              environment_from_files:
                - ./ecs/env/common.env
              environment:
                - RAILS_ENV: production
                - MIGRATION_VERBOSE: true
              secrets_from_files:
                - ./ecs/secrets/production.env
```
  この場合、environment は run-task の containerOverrides に入り、secrets は新しい task definition に反映されます。true や数値は最終的に文字列化されます。

  例3: scheduled task で定期バッチの設定を外出しする例
```
  clusters:
    - name: prod
      scheduled_tasks:
        - rule: nightly-batch
          expression: cron(0 18 * * ? *)
          targets:
            - name: aggregate
              path: ecs/task_definition/batch.yml
              containers:
                - name: batch
                  image: 123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/batch:latest
              container_overrides:
                - name: batch
                  command: ["bundle", "exec", "rails", "runner", "Batch::Aggregate.call"]
                  environment_from_files:
                    - ./ecs/env/batch.yml
                  secrets_from_files:
                    - ./ecs/secrets/production.env
```
  scheduled task でも同じルールで解決されますが、CloudWatch Events 側の containerOverrides には secrets は出さず、task definition 側に寄せる動きです。

  補足すると、このブランチの価値は「deploy.yml に secrets ARN や大量の環境変数を直書きしなくて済む」「service/run_task/scheduled_task で同じ記法を使える」「同名キーの上書き順が一貫している」の3点です。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded container override support for run tasks, services, and scheduled tasks, including file-backed environment and secret entries (YAML and dotenv) merged with inline values; overrides can include environment, secrets, and file-based sources.
* **Bug Fixes / Behavior**
  * Deterministic merging and precedence: inline values override files; container override selection precedence clarified; secrets omitted from runtime RPCs but applied to task definitions.
* **Tests**
  * Added coverage for file loading, parsing, merging, coercion, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->