### PR TITLE
Add deploy text parameter

### DIFF
--- a/app/api/v2/slack_routes.rb
+++ b/app/api/v2/slack_routes.rb
@@ -32,9 +32,12 @@ module V2
           elements = params.dig(:event, :blocks, 0, :elements, 0, :elements)
 
           user = elements.find { |k, _v| k[:type] == 'user' }
-          element = elements.find { |k, _v| k[:type] == 'text' }
-
-          statement = element.present? ? element[:text].strip.delete("\u00A0") : ''
+          statement = elements.drop_while { |e| e[:type] != 'user' }.drop(1).filter_map do |e|
+            case e[:type]
+            when 'text' then e[:text]
+            when 'link' then e[:url]
+            end
+          end.join.strip.delete(" ")
 
           key = "event_ts:#{params[:event][:event_ts]}"
           id = Genova::Sidekiq::JobStore.create(key, {

--- a/app/api/v2/slack_routes.rb
+++ b/app/api/v2/slack_routes.rb
@@ -38,7 +38,7 @@ module V2
             when 'link' then e[:url]
             else nil
             end
-          end.join.strip.delete(' ')
+          end.join.strip.delete("\u00A0")
 
           key = "event_ts:#{params[:event][:event_ts]}"
           id = Genova::Sidekiq::JobStore.create(key, {

--- a/app/api/v2/slack_routes.rb
+++ b/app/api/v2/slack_routes.rb
@@ -36,6 +36,7 @@ module V2
             case e[:type]
             when 'text' then e[:text]
             when 'link' then e[:url]
+            else nil
             end
           end.join.strip.delete(' ')
 

--- a/app/api/v2/slack_routes.rb
+++ b/app/api/v2/slack_routes.rb
@@ -37,7 +37,7 @@ module V2
             when 'text' then e[:text]
             when 'link' then e[:url]
             end
-          end.join.strip.delete(" ")
+          end.join.strip.delete(' ')
 
           key = "event_ts:#{params[:event][:event_ts]}"
           id = Genova::Sidekiq::JobStore.create(key, {

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -4,6 +4,8 @@ class DeployJob
 
   extend Enumerize
 
+  NOTE_MAX_LENGTH = 3000
+
   enumerize :type, in: %i[run_task service scheduled_task]
   enumerize :status, in: %i[initial provisioning deploying success failure reserved_cancel cancel]
   enumerize :mode, in: %i[manual auto slack]
@@ -39,7 +41,10 @@ class DeployJob
   field :note, type: String
 
   validates :mode, :account, :repository, :cluster, presence: true
+  validates :note, length: { maximum: NOTE_MAX_LENGTH }, allow_blank: true
   validate :check_type
+
+  before_validation :truncate_note
 
   def self.generate_id
     Time.now.utc.strftime('%Y%m%d-%H%M%S')
@@ -194,5 +199,9 @@ class DeployJob
 
   def check_type
     errors[:base] << 'Please specify deploy type.' unless type.present?
+  end
+
+  def truncate_note
+    self.note = note.to_s.truncate(NOTE_MAX_LENGTH, omission: '') if note.present?
   end
 end

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -36,7 +36,7 @@ class DeployJob
   field :docker_build_time, type: Float
   field :execution_time, type: Float
   field :deployment_tag, type: String
-  field :text, type: String
+  field :generic_text, type: String
 
   validates :mode, :account, :repository, :cluster, presence: true
   validate :check_type

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -36,7 +36,7 @@ class DeployJob
   field :docker_build_time, type: Float
   field :execution_time, type: Float
   field :deployment_tag, type: String
-  field :memo, type: String
+  field :note, type: String
 
   validates :mode, :account, :repository, :cluster, presence: true
   validate :check_type

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -36,6 +36,7 @@ class DeployJob
   field :docker_build_time, type: Float
   field :execution_time, type: Float
   field :deployment_tag, type: String
+  field :text, type: String
 
   validates :mode, :account, :repository, :cluster, presence: true
   validate :check_type

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -4,7 +4,7 @@ class DeployJob
 
   extend Enumerize
 
-  NOTE_MAX_LENGTH = 3000
+  NOTE_MAX_LENGTH = 1000
 
   enumerize :type, in: %i[run_task service scheduled_task]
   enumerize :status, in: %i[initial provisioning deploying success failure reserved_cancel cancel]

--- a/app/models/deploy_job.rb
+++ b/app/models/deploy_job.rb
@@ -36,7 +36,7 @@ class DeployJob
   field :docker_build_time, type: Float
   field :execution_time, type: Float
   field :deployment_tag, type: String
-  field :generic_text, type: String
+  field :memo, type: String
 
   validates :mode, :account, :repository, :cluster, presence: true
   validate :check_type

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -98,7 +98,13 @@
       <% if @deploy_job.generic_text.present? %>
         <div class="columns">
           <dt class="column is-2">Generic text</dt>
-          <dd class="column is-4"><%= @deploy_job.generic_text %></dd>
+          <dd class="column is-4">
+            <% if @deploy_job.generic_text.match?(/\Ahttps?:\/\//) %>
+              <%= link_to @deploy_job.generic_text, @deploy_job.generic_text, target: '_blank', rel: 'noopener noreferrer' %>
+            <% else %>
+              <%= @deploy_job.generic_text %>
+            <% end %>
+          </dd>
         </div>
       <% end %>
       <% if @deploy_job.task_definition_arn.present? %>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -95,14 +95,14 @@
           <dd class="column is-4"><%= @deploy_job.slack_user_name %></dd>
         </div>
       <% end %>
-      <% if @deploy_job.memo.present? %>
+      <% if @deploy_job.note.present? %>
         <div class="columns">
-          <dt class="column is-2">Memo</dt>
+          <dt class="column is-2">Note</dt>
           <dd class="column is-4">
-            <% if @deploy_job.memo.match?(/\Ahttps?:\/\//) %>
-              <%= link_to @deploy_job.memo, @deploy_job.memo, target: '_blank', rel: 'noopener noreferrer' %>
+            <% if @deploy_job.note.match?(/\Ahttps?:\/\//) %>
+              <%= link_to @deploy_job.note, @deploy_job.note, target: '_blank', rel: 'noopener noreferrer' %>
             <% else %>
-              <%= @deploy_job.memo %>
+              <%= @deploy_job.note %>
             <% end %>
           </dd>
         </div>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -99,11 +99,9 @@
         <div class="columns">
           <dt class="column is-2">Note</dt>
           <dd class="column is-4">
-            <% if @deploy_job.note.match?(/\Ahttps?:\/\//) %>
-              <%= link_to @deploy_job.note, @deploy_job.note, target: '_blank', rel: 'noopener noreferrer' %>
-            <% else %>
-              <%= safe_join(@deploy_job.note.split(/\r?\n/).map { |line| h(line) }, tag.br) %>
-            <% end %>
+            <%= safe_join(@deploy_job.note.split(/\r?\n/).map { |line|
+                  line.match?(/\Ahttps?:\/\/\S+\z/) ? link_to(line, line, target: '_blank', rel: 'noopener noreferrer') : h(line)
+                }, tag.br) %>
           </dd>
         </div>
       <% end %>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -102,7 +102,7 @@
             <% if @deploy_job.note.match?(/\Ahttps?:\/\//) %>
               <%= link_to @deploy_job.note, @deploy_job.note, target: '_blank', rel: 'noopener noreferrer' %>
             <% else %>
-              <%= @deploy_job.note %>
+              <%= safe_join(@deploy_job.note.split(/\r?\n/).map { |line| h(line) }, tag.br) %>
             <% end %>
           </dd>
         </div>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -95,14 +95,14 @@
           <dd class="column is-4"><%= @deploy_job.slack_user_name %></dd>
         </div>
       <% end %>
-      <% if @deploy_job.generic_text.present? %>
+      <% if @deploy_job.memo.present? %>
         <div class="columns">
-          <dt class="column is-2">Generic text</dt>
+          <dt class="column is-2">Memo</dt>
           <dd class="column is-4">
-            <% if @deploy_job.generic_text.match?(/\Ahttps?:\/\//) %>
-              <%= link_to @deploy_job.generic_text, @deploy_job.generic_text, target: '_blank', rel: 'noopener noreferrer' %>
+            <% if @deploy_job.memo.match?(/\Ahttps?:\/\//) %>
+              <%= link_to @deploy_job.memo, @deploy_job.memo, target: '_blank', rel: 'noopener noreferrer' %>
             <% else %>
-              <%= @deploy_job.generic_text %>
+              <%= @deploy_job.memo %>
             <% end %>
           </dd>
         </div>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -95,6 +95,12 @@
           <dd class="column is-4"><%= @deploy_job.slack_user_name %></dd>
         </div>
       <% end %>
+      <% if @deploy_job.generic_text.present? %>
+        <div class="columns">
+          <dt class="column is-2">Generic text</dt>
+          <dd class="column is-4"><%= @deploy_job.generic_text %></dd>
+        </div>
+      <% end %>
       <% if @deploy_job.task_definition_arn.present? %>
         <div class="columns">
           <dt class="column is-2">Task definition ARN</dt>

--- a/app/workers/slack/command_receive_worker.rb
+++ b/app/workers/slack/command_receive_worker.rb
@@ -24,7 +24,7 @@ module Slack
       if statement.size > 1
         params = statement.slice(1..)
         params.each do |param|
-          element = param.split('=')
+          element = param.split('=', 2)
           key = element[0].tr('-', '_').to_sym
           statements[:params][key] = element[1]
         end

--- a/app/workers/slack/deploy_worker.rb
+++ b/app/workers/slack/deploy_worker.rb
@@ -28,7 +28,7 @@ module Slack
                                      service: params[:service],
                                      scheduled_task_rule: params[:scheduled_task_rule],
                                      scheduled_task_target: params[:scheduled_task_target],
-                                     text: params[:text])
+                                     generic_text: params[:generic_text])
 
       history = Genova::Slack::Interactive::History.new(deploy_job.slack_user_id)
       history.add(deploy_job)

--- a/app/workers/slack/deploy_worker.rb
+++ b/app/workers/slack/deploy_worker.rb
@@ -28,7 +28,7 @@ module Slack
                                      service: params[:service],
                                      scheduled_task_rule: params[:scheduled_task_rule],
                                      scheduled_task_target: params[:scheduled_task_target],
-                                     memo: params[:memo])
+                                     note: params[:note])
 
       history = Genova::Slack::Interactive::History.new(deploy_job.slack_user_id)
       history.add(deploy_job)

--- a/app/workers/slack/deploy_worker.rb
+++ b/app/workers/slack/deploy_worker.rb
@@ -28,7 +28,7 @@ module Slack
                                      service: params[:service],
                                      scheduled_task_rule: params[:scheduled_task_rule],
                                      scheduled_task_target: params[:scheduled_task_target],
-                                     generic_text: params[:generic_text])
+                                     memo: params[:memo])
 
       history = Genova::Slack::Interactive::History.new(deploy_job.slack_user_id)
       history.add(deploy_job)

--- a/app/workers/slack/deploy_worker.rb
+++ b/app/workers/slack/deploy_worker.rb
@@ -27,7 +27,8 @@ module Slack
                                      override_command: params[:override_command],
                                      service: params[:service],
                                      scheduled_task_rule: params[:scheduled_task_rule],
-                                     scheduled_task_target: params[:scheduled_task_target])
+                                     scheduled_task_target: params[:scheduled_task_target],
+                                     text: params[:text])
 
       history = Genova::Slack::Interactive::History.new(deploy_job.slack_user_id)
       history.add(deploy_job)

--- a/lib/autoloads/genova/deploy/step/runner.rb
+++ b/lib/autoloads/genova/deploy/step/runner.rb
@@ -26,7 +26,8 @@ module Genova
                   service:,
                   scheduled_task_rule:,
                   scheduled_task_target:,
-                  run_task:
+                  run_task:,
+                  memo: options[:memo]
                 )
 
                 callback.start_deploy(deploy_job:)

--- a/lib/autoloads/genova/deploy/step/runner.rb
+++ b/lib/autoloads/genova/deploy/step/runner.rb
@@ -27,7 +27,7 @@ module Genova
                   scheduled_task_rule:,
                   scheduled_task_target:,
                   run_task:,
-                  memo: options[:memo]
+                  note: options[:note]
                 )
 
                 callback.start_deploy(deploy_job:)

--- a/lib/autoloads/genova/slack/block_kit/helper.rb
+++ b/lib/autoloads/genova/slack/block_kit/helper.rb
@@ -169,6 +169,10 @@ module Genova
           def escape_emoji(string)
             string.gsub(/:(\w+):/, ":\u00AD\\1\u00AD:")
           end
+
+          def escape_mrkdwn(string)
+            string.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+          end
         end
       end
     end

--- a/lib/autoloads/genova/slack/block_kit/helper.rb
+++ b/lib/autoloads/genova/slack/block_kit/helper.rb
@@ -169,10 +169,6 @@ module Genova
           def escape_emoji(string)
             string.gsub(/:(\w+):/, ":\u00AD\\1\u00AD:")
           end
-
-          def escape_mrkdwn(string)
-            string.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
-          end
         end
       end
     end

--- a/lib/autoloads/genova/slack/block_kit/helper.rb
+++ b/lib/autoloads/genova/slack/block_kit/helper.rb
@@ -68,6 +68,7 @@ module Genova
               }
             }
             block[:block_id] = options[:block_id] if options[:block_id].present?
+            block[:element][:multiline] = options[:multiline] unless options[:multiline].nil?
             block
           end
 

--- a/lib/autoloads/genova/slack/command/deploy.rb
+++ b/lib/autoloads/genova/slack/command/deploy.rb
@@ -28,7 +28,7 @@ module Genova
               service: result[:service],
               scheduled_task_rule: result[:scheduled_task_rule],
               scheduled_task_target: result[:scheduled_task_target],
-              text: result[:text]
+              generic_text: result[:generic_text]
             }
 
             session_store.merge(params)

--- a/lib/autoloads/genova/slack/command/deploy.rb
+++ b/lib/autoloads/genova/slack/command/deploy.rb
@@ -27,7 +27,8 @@ module Genova
               run_task: result[:run_task],
               service: result[:service],
               scheduled_task_rule: result[:scheduled_task_rule],
-              scheduled_task_target: result[:scheduled_task_target]
+              scheduled_task_target: result[:scheduled_task_target],
+              text: result[:text]
             }
 
             session_store.merge(params)

--- a/lib/autoloads/genova/slack/command/deploy.rb
+++ b/lib/autoloads/genova/slack/command/deploy.rb
@@ -28,7 +28,7 @@ module Genova
               service: result[:service],
               scheduled_task_rule: result[:scheduled_task_rule],
               scheduled_task_target: result[:scheduled_task_target],
-              memo: result[:memo]
+              note: result[:note]
             }
 
             session_store.merge(params)

--- a/lib/autoloads/genova/slack/command/deploy.rb
+++ b/lib/autoloads/genova/slack/command/deploy.rb
@@ -28,7 +28,7 @@ module Genova
               service: result[:service],
               scheduled_task_rule: result[:scheduled_task_rule],
               scheduled_task_target: result[:scheduled_task_target],
-              generic_text: result[:generic_text]
+              memo: result[:memo]
             }
 
             session_store.merge(params)

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -130,7 +130,7 @@ module Genova
           blocks = []
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
-          blocks << BlockKit::Helper.plain_text_input('submit_deploy_text', 'Text (optional)', placeholder: 'Input any text', block_id: 'deploy_text')
+          blocks << BlockKit::Helper.plain_text_input('submit_deploy_generic_text', 'Generic text (optional)', placeholder: 'Input any text', block_id: 'deploy_generic_text')
           blocks << BlockKit::Helper.actions([
                                                BlockKit::Helper.primary_button('Deploy', 'deploy', 'submit_deploy'),
                                                BlockKit::Helper.button('Cancel', 'cancel', 'submit_cancel')

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -131,11 +131,11 @@ module Genova
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
-          if params[:memo].present?
-            blocks << BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Memo', params[:memo])])
-          else
-            blocks << BlockKit::Helper.plain_text_input('submit_deploy_memo', 'Memo (optional)', placeholder: 'Input any text', block_id: 'deploy_memo')
-          end
+          blocks << if params[:memo].present?
+                      BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Memo', params[:memo])])
+                    else
+                      BlockKit::Helper.plain_text_input('submit_deploy_memo', 'Memo (optional)', placeholder: 'Input any text', block_id: 'deploy_memo')
+                    end
 
           blocks << BlockKit::Helper.actions([
                                                BlockKit::Helper.primary_button('Deploy', 'deploy', 'submit_deploy'),

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -130,7 +130,13 @@ module Genova
           blocks = []
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
-          blocks << BlockKit::Helper.plain_text_input('submit_deploy_generic_text', 'Generic text (optional)', placeholder: 'Input any text', block_id: 'deploy_generic_text')
+
+          if params[:generic_text].present?
+            blocks << BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Generic text', params[:generic_text])])
+          else
+            blocks << BlockKit::Helper.plain_text_input('submit_deploy_generic_text', 'Generic text (optional)', placeholder: 'Input any text', block_id: 'deploy_generic_text')
+          end
+
           blocks << BlockKit::Helper.actions([
                                                BlockKit::Helper.primary_button('Deploy', 'deploy', 'submit_deploy'),
                                                BlockKit::Helper.button('Cancel', 'cancel', 'submit_cancel')

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -131,10 +131,10 @@ module Genova
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
-          blocks << if params[:memo].present?
-                      BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Memo', params[:memo])])
+          blocks << if params[:note].present?
+                      BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Note', params[:note])])
                     else
-                      BlockKit::Helper.plain_text_input('submit_deploy_memo', 'Memo (optional)', placeholder: 'Input any text', block_id: 'deploy_memo')
+                      BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note')
                     end
 
           blocks << BlockKit::Helper.actions([

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -132,8 +132,7 @@ module Genova
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
           blocks << if params[:note].present?
-                      note = BlockKit::Helper.escape_mrkdwn(params[:note])
-                      BlockKit::Helper.section_fieldset([BlockKit::Helper.section_field('Note', note)])
+                      BlockKit::Helper.section_fieldset([BlockKit::Helper.section_field('Note', params[:note])])
                     else
                       BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note', multiline: true)
                     end

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -130,6 +130,7 @@ module Genova
           blocks = []
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
+          blocks << BlockKit::Helper.plain_text_input('submit_deploy_text', 'Text (optional)', placeholder: 'Input any text', block_id: 'deploy_text')
           blocks << BlockKit::Helper.actions([
                                                BlockKit::Helper.primary_button('Deploy', 'deploy', 'submit_deploy'),
                                                BlockKit::Helper.button('Cancel', 'cancel', 'submit_cancel')

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -132,7 +132,8 @@ module Genova
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
           blocks << if params[:note].present?
-                      BlockKit::Helper.section_fieldset([BlockKit::Helper.section_field('Note', params[:note])])
+                      note = BlockKit::Helper.escape_mrkdwn(params[:note])
+                      BlockKit::Helper.section_fieldset([BlockKit::Helper.section_field('Note', note)])
                     else
                       BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note', multiline: true)
                     end

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -131,10 +131,10 @@ module Genova
           blocks << BlockKit::Helper.section('Ready to deploy!')
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
-          if params[:generic_text].present?
-            blocks << BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Generic text', params[:generic_text])])
+          if params[:memo].present?
+            blocks << BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Memo', params[:memo])])
           else
-            blocks << BlockKit::Helper.plain_text_input('submit_deploy_generic_text', 'Generic text (optional)', placeholder: 'Input any text', block_id: 'deploy_generic_text')
+            blocks << BlockKit::Helper.plain_text_input('submit_deploy_memo', 'Memo (optional)', placeholder: 'Input any text', block_id: 'deploy_memo')
           end
 
           blocks << BlockKit::Helper.actions([

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -132,9 +132,9 @@ module Genova
           blocks << BlockKit::Helper.section_short_fieldset([git_compare(params)]) unless params[:type] == DeployJob.type.find_value(:run_task)
 
           blocks << if params[:note].present?
-                      BlockKit::Helper.section_short_fieldset([BlockKit::Helper.section_short_field('Note', params[:note])])
+                      BlockKit::Helper.section_fieldset([BlockKit::Helper.section_field('Note', params[:note])])
                     else
-                      BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note')
+                      BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note', multiline: true)
                     end
 
           blocks << BlockKit::Helper.actions([

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -158,8 +158,8 @@ module Genova
           permission = Interactive::Permission.new(@payload[:user][:id])
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_cluster?(@session_store.params[:cluster]) || permission.allow_repository?(@session_store.params[:repository])
 
-          generic_text = @payload.dig(:state, :values, :deploy_generic_text, :submit_deploy_generic_text, :value)
-          @session_store.merge({ generic_text: generic_text }) if generic_text.present?
+          memo = @payload.dig(:state, :values, :deploy_memo, :submit_deploy_memo, :value)
+          @session_store.merge({ memo: memo }) if memo.present?
 
           ::Slack::DeployWorker.perform_async(@thread_ts)
 

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -159,7 +159,7 @@ module Genova
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_cluster?(@session_store.params[:cluster]) || permission.allow_repository?(@session_store.params[:repository])
 
           memo = @payload.dig(:state, :values, :deploy_memo, :submit_deploy_memo, :value)
-          @session_store.merge({ memo: memo }) if memo.present?
+          @session_store.merge({ memo: }) if memo.present?
 
           ::Slack::DeployWorker.perform_async(@thread_ts)
 

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -158,6 +158,9 @@ module Genova
           permission = Interactive::Permission.new(@payload[:user][:id])
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_cluster?(@session_store.params[:cluster]) || permission.allow_repository?(@session_store.params[:repository])
 
+          text = @payload.dig(:state, :values, :deploy_text, :submit_deploy_text, :value)
+          @session_store.merge(text:) if text.present?
+
           ::Slack::DeployWorker.perform_async(@thread_ts)
 
           show_message('Deployment started.')

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -158,8 +158,8 @@ module Genova
           permission = Interactive::Permission.new(@payload[:user][:id])
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_cluster?(@session_store.params[:cluster]) || permission.allow_repository?(@session_store.params[:repository])
 
-          text = @payload.dig(:state, :values, :deploy_text, :submit_deploy_text, :value)
-          @session_store.merge(text:) if text.present?
+          generic_text = @payload.dig(:state, :values, :deploy_generic_text, :submit_deploy_generic_text, :value)
+          @session_store.merge({ generic_text: generic_text }) if generic_text.present?
 
           ::Slack::DeployWorker.perform_async(@thread_ts)
 

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -158,8 +158,8 @@ module Genova
           permission = Interactive::Permission.new(@payload[:user][:id])
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_cluster?(@session_store.params[:cluster]) || permission.allow_repository?(@session_store.params[:repository])
 
-          memo = @payload.dig(:state, :values, :deploy_memo, :submit_deploy_memo, :value)
-          @session_store.merge({ memo: }) if memo.present?
+          note = @payload.dig(:state, :values, :deploy_note, :submit_deploy_note, :value)
+          @session_store.merge({ note: }) if note.present?
 
           ::Slack::DeployWorker.perform_async(@thread_ts)
 

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -113,7 +113,8 @@ module GenovaCli
         options[:name],
         ::Genova::Deploy::Step::StdoutHook.new,
         mode: DeployJob.mode.find_value(:manual),
-        force: options[:force]
+        force: options[:force],
+        memo: options[:memo]
       )
     end
   end

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -7,6 +7,7 @@ module GenovaCli
     class_option :force, default: false, type: :boolean, aliases: :f, desc: 'If true is specified, it forces a deployment.'
     class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Show confirmation message before deploying.'
     class_option :tag, desc: 'Tag to deploy.'
+    class_option :text, desc: 'Arbitrary text to attach to the deploy job.'
     class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Outputting detailed logs.'
 
     no_commands do
@@ -44,7 +45,8 @@ module GenovaCli
           repository: repository_settings.present? ? repository_settings[:name] : options[:repository],
           run_task: options[:run_task],
           override_container: options[:override_container],
-          override_command: options[:override_command]
+          override_command: options[:override_command],
+          text: options[:text]
         )
 
         raise ::Genova::Exceptions::ValidationError, deploy_job.errors.full_messages[0] unless deploy_job.save

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -7,7 +7,7 @@ module GenovaCli
     class_option :force, default: false, type: :boolean, aliases: :f, desc: 'If true is specified, it forces a deployment.'
     class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Show confirmation message before deploying.'
     class_option :tag, desc: 'Tag to deploy.'
-    class_option :generic_text, desc: 'Arbitrary text to attach to the deploy job.'
+    class_option :memo, desc: 'Arbitrary text to attach to the deploy job.'
     class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Outputting detailed logs.'
 
     no_commands do
@@ -46,7 +46,7 @@ module GenovaCli
           run_task: options[:run_task],
           override_container: options[:override_container],
           override_command: options[:override_command],
-          generic_text: options[:generic_text]
+          memo: options[:memo]
         )
 
         raise ::Genova::Exceptions::ValidationError, deploy_job.errors.full_messages[0] unless deploy_job.save

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -7,7 +7,7 @@ module GenovaCli
     class_option :force, default: false, type: :boolean, aliases: :f, desc: 'If true is specified, it forces a deployment.'
     class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Show confirmation message before deploying.'
     class_option :tag, desc: 'Tag to deploy.'
-    class_option :memo, desc: 'Arbitrary text to attach to the deploy job.'
+    class_option :memo, aliases: :m, desc: 'Arbitrary text to attach to the deploy job.'
     class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Outputting detailed logs.'
 
     no_commands do

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -7,7 +7,7 @@ module GenovaCli
     class_option :force, default: false, type: :boolean, aliases: :f, desc: 'If true is specified, it forces a deployment.'
     class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Show confirmation message before deploying.'
     class_option :tag, desc: 'Tag to deploy.'
-    class_option :memo, aliases: :m, desc: 'Arbitrary text to attach to the deploy job.'
+    class_option :note, desc: 'Arbitrary text to attach to the deploy job.'
     class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Outputting detailed logs.'
 
     no_commands do
@@ -46,7 +46,7 @@ module GenovaCli
           run_task: options[:run_task],
           override_container: options[:override_container],
           override_command: options[:override_command],
-          memo: options[:memo]
+          note: options[:note]
         )
 
         raise ::Genova::Exceptions::ValidationError, deploy_job.errors.full_messages[0] unless deploy_job.save
@@ -114,7 +114,7 @@ module GenovaCli
         ::Genova::Deploy::Step::StdoutHook.new,
         mode: DeployJob.mode.find_value(:manual),
         force: options[:force],
-        memo: options[:memo]
+        note: options[:note]
       )
     end
   end

--- a/lib/tasks/deploy.rb
+++ b/lib/tasks/deploy.rb
@@ -7,7 +7,7 @@ module GenovaCli
     class_option :force, default: false, type: :boolean, aliases: :f, desc: 'If true is specified, it forces a deployment.'
     class_option :interactive, default: false, type: :boolean, aliases: :i, desc: 'Show confirmation message before deploying.'
     class_option :tag, desc: 'Tag to deploy.'
-    class_option :text, desc: 'Arbitrary text to attach to the deploy job.'
+    class_option :generic_text, desc: 'Arbitrary text to attach to the deploy job.'
     class_option :verbose, default: false, type: :boolean, aliases: :v, desc: 'Outputting detailed logs.'
 
     no_commands do
@@ -46,7 +46,7 @@ module GenovaCli
           run_task: options[:run_task],
           override_container: options[:override_container],
           override_command: options[:override_command],
-          text: options[:text]
+          generic_text: options[:generic_text]
         )
 
         raise ::Genova::Exceptions::ValidationError, deploy_job.errors.full_messages[0] unless deploy_job.save

--- a/spec/api/v2/slack_routes_spec.rb
+++ b/spec/api/v2/slack_routes_spec.rb
@@ -80,6 +80,39 @@ module V2
           expect(response).to have_http_status :created
           expect(response.body).to eq('"challenge"')
         end
+
+        it 'ignores unsupported block elements when building statement' do
+          allow(Slack::CommandReceiveWorker).to receive(:perform_async)
+
+          post '/api/v2/slack/event', params: {
+            event: {
+              user: 'sender',
+              ts: 'parent_ts',
+              event_ts: 'event_ts',
+              blocks: [
+                {
+                  elements: [
+                    {
+                      elements: [
+                        { type: 'user', user_id: 'mention_user' },
+                        { type: 'text', text: 'deploy:service ' },
+                        { type: 'emoji', name: 'rocket' },
+                        { type: 'link', url: 'https://example.com' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+
+          key = Genova::Sidekiq::JobStore.send(:generate_key, 'event_ts:event_ts')
+          value = Genova::Sidekiq::JobStore.find(key)
+
+          expect(value[:statement]).to eq('deploy:service https://example.com')
+          expect(value[:mention_user]).to eq('mention_user')
+          expect(Slack::CommandReceiveWorker).to have_received(:perform_async).with(key)
+        end
       end
     end
   end

--- a/spec/api/v2/slack_routes_spec.rb
+++ b/spec/api/v2/slack_routes_spec.rb
@@ -95,7 +95,7 @@ module V2
                     {
                       elements: [
                         { type: 'user', user_id: 'mention_user' },
-                        { type: 'text', text: 'deploy:service ' },
+                        { type: 'text', text: "deploy:service\u00A0" },
                         { type: 'emoji', name: 'rocket' },
                         { type: 'link', url: 'https://example.com' }
                       ]

--- a/spec/controllers/deploy_hobs_controller_spec.rb
+++ b/spec/controllers/deploy_hobs_controller_spec.rb
@@ -57,6 +57,34 @@ RSpec.describe DeployJobsController, type: :controller do
           expect(response.body).not_to include('<b>first line</b>')
         end
       end
+
+      context 'when note starts with url and includes another line' do
+        render_views
+
+        let(:deploy_job) do
+          DeployJob.create!(
+            id: DeployJob.generate_id,
+            mode: DeployJob.mode.find_value(:manual),
+            type: DeployJob.type.find_value(:service),
+            account: Settings.github.account,
+            repository: 'repository',
+            cluster: 'cluster',
+            service: 'service',
+            task_definition_arn: 'new_task_definition_arn',
+            note: "https://example.com\naaaa"
+          )
+        end
+
+        it 'renders only the url line as a link and keeps line breaks' do
+          get :show, params: { id: deploy_job.id }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('href="https://example.com"')
+          expect(response.body).to include('>https://example.com</a><br')
+          expect(response.body).to include('aaaa')
+          expect(response.body).not_to include('href="https://example.com%0Aaaaa"')
+        end
+      end
     end
 
     context 'when DeployJob not exist.' do

--- a/spec/controllers/deploy_hobs_controller_spec.rb
+++ b/spec/controllers/deploy_hobs_controller_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe DeployJobsController, type: :controller do
       it 'should return 200' do
         expect(get(:show, params: { id: deploy_job.id })).to have_http_status(:ok)
       end
+
+      context 'when note contains line breaks' do
+        render_views
+
+        let(:deploy_job) do
+          DeployJob.create!(
+            id: DeployJob.generate_id,
+            mode: DeployJob.mode.find_value(:manual),
+            type: DeployJob.type.find_value(:service),
+            account: Settings.github.account,
+            repository: 'repository',
+            cluster: 'cluster',
+            service: 'service',
+            task_definition_arn: 'new_task_definition_arn',
+            note: "<b>first line</b>\nsecond line"
+          )
+        end
+
+        it 'renders escaped note with line breaks' do
+          get :show, params: { id: deploy_job.id }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('&lt;b&gt;first line&lt;/b&gt;<br')
+          expect(response.body).to include('second line')
+          expect(response.body).not_to include('<b>first line</b>')
+        end
+      end
     end
 
     context 'when DeployJob not exist.' do

--- a/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
+++ b/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
@@ -39,6 +39,12 @@ module Genova
             it 'should not error' do
               expect { Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym) }.to_not raise_error
             end
+
+            it 'stores memo in deploy job' do
+              Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym, memo: 'memo')
+
+              expect(DeployJob.last.memo).to eq('memo')
+            end
           end
 
           context 'when update run task' do

--- a/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
+++ b/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
@@ -40,10 +40,10 @@ module Genova
               expect { Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym) }.to_not raise_error
             end
 
-            it 'stores memo in deploy job' do
-              Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym, memo: 'memo')
+            it 'stores note in deploy job' do
+              Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym, note: 'note')
 
-              expect(DeployJob.last.memo).to eq('memo')
+              expect(DeployJob.last.note).to eq('note')
             end
           end
 

--- a/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
+++ b/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
@@ -45,6 +45,17 @@ module Genova
 
               expect(DeployJob.last.note).to eq('note')
             end
+
+            it 'truncates too long note before storing in deploy job' do
+              Runner.call(
+                steps,
+                StdoutHook.new,
+                mode: DeployJob.mode.find_value(:manual).to_sym,
+                note: 'a' * (DeployJob::NOTE_MAX_LENGTH + 1)
+              )
+
+              expect(DeployJob.last.note.length).to eq(DeployJob::NOTE_MAX_LENGTH)
+            end
           end
 
           context 'when update run task' do

--- a/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
+++ b/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
@@ -12,6 +12,14 @@ module Genova
           end
         end
 
+        describe 'escape_mrkdwn' do
+          it 'escapes reserved mrkdwn characters' do
+            text = '<img src="test">&text'
+
+            expect(Genova::Slack::BlockKit::Helper.escape_mrkdwn(text)).to eq('&lt;img src="test"&gt;&amp;text')
+          end
+        end
+
         describe 'escape_emoji' do
           it 'should escape string' do
             expect(Genova::Slack::BlockKit::Helper.send(:escape_emoji, ':test:')).to eq(":\u00ADtest\u00AD:")

--- a/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
+++ b/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
@@ -4,6 +4,14 @@ module Genova
   module Slack
     module BlockKit
       describe Helper do
+        describe 'plain_text_input' do
+          it 'supports multiline input' do
+            block = Genova::Slack::BlockKit::Helper.plain_text_input('action', 'Label', placeholder: 'Input text', multiline: true)
+
+            expect(block[:element][:multiline]).to eq(true)
+          end
+        end
+
         describe 'escape_emoji' do
           it 'should escape string' do
             expect(Genova::Slack::BlockKit::Helper.send(:escape_emoji, ':test:')).to eq(":\u00ADtest\u00AD:")

--- a/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
+++ b/spec/lib/autoloads/genova/slack/block_kit/helper_spec.rb
@@ -12,14 +12,6 @@ module Genova
           end
         end
 
-        describe 'escape_mrkdwn' do
-          it 'escapes reserved mrkdwn characters' do
-            text = '<img src="test">&text'
-
-            expect(Genova::Slack::BlockKit::Helper.escape_mrkdwn(text)).to eq('&lt;img src="test"&gt;&amp;text')
-          end
-        end
-
         describe 'escape_emoji' do
           it 'should escape string' do
             expect(Genova::Slack::BlockKit::Helper.send(:escape_emoji, ':test:')).to eq(":\u00ADtest\u00AD:")

--- a/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
+++ b/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
@@ -144,6 +144,27 @@ module Genova
 
             bot.ask_confirm_deploy(params.merge(note: "line1\nline2"), show_target: false)
           end
+
+          it 'escapes mrkdwn in note before sending to Slack' do
+            allow(code_manager).to receive(:origin_last_commit).and_return('xxx')
+            allow(code_manager).to receive(:find_commit).and_return('yyy')
+            allow(Genova::CodeManager::Git).to receive(:new).and_return(code_manager)
+            allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
+            allow(describe_services_response).to receive(:services).and_return([service])
+            allow(ecs_client).to receive(:describe_services).and_return(describe_services_response)
+            allow(service).to receive(:task_definition)
+            allow(describe_task_definition_response).to receive(:[]).with(:tags).and_return([{ key: 'genova.build' }])
+            allow(ecs_client).to receive(:describe_task_definition).and_return(describe_task_definition_response)
+
+            expect(client).to receive(:chat_postMessage) do |data|
+              note_block = data[:blocks].find do |block|
+                block[:type] == 'section' && block.dig(:text, :text)&.include?('*Note:*')
+              end
+              expect(note_block.dig(:text, :text)).to include('&lt;img src="test"&gt;')
+            end
+
+            bot.ask_confirm_deploy(params.merge(note: '<img src="test">'), show_target: false)
+          end
         end
 
         describe 'detect_auto_deploy' do

--- a/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
+++ b/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
@@ -144,27 +144,6 @@ module Genova
 
             bot.ask_confirm_deploy(params.merge(note: "line1\nline2"), show_target: false)
           end
-
-          it 'escapes mrkdwn in note before sending to Slack' do
-            allow(code_manager).to receive(:origin_last_commit).and_return('xxx')
-            allow(code_manager).to receive(:find_commit).and_return('yyy')
-            allow(Genova::CodeManager::Git).to receive(:new).and_return(code_manager)
-            allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
-            allow(describe_services_response).to receive(:services).and_return([service])
-            allow(ecs_client).to receive(:describe_services).and_return(describe_services_response)
-            allow(service).to receive(:task_definition)
-            allow(describe_task_definition_response).to receive(:[]).with(:tags).and_return([{ key: 'genova.build' }])
-            allow(ecs_client).to receive(:describe_task_definition).and_return(describe_task_definition_response)
-
-            expect(client).to receive(:chat_postMessage) do |data|
-              note_block = data[:blocks].find do |block|
-                block[:type] == 'section' && block.dig(:text, :text)&.include?('*Note:*')
-              end
-              expect(note_block.dig(:text, :text)).to include('&lt;img src="test"&gt;')
-            end
-
-            bot.ask_confirm_deploy(params.merge(note: '<img src="test">'), show_target: false)
-          end
         end
 
         describe 'detect_auto_deploy' do

--- a/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
+++ b/spec/lib/autoloads/genova/slack/interactive/bot_spec.rb
@@ -103,6 +103,47 @@ module Genova
 
             expect { bot.ask_confirm_deploy(params, show_target: true) }.not_to raise_error
           end
+
+          it 'uses multiline note input when note is absent' do
+            allow(code_manager).to receive(:origin_last_commit).and_return('xxx')
+            allow(code_manager).to receive(:find_commit).and_return('yyy')
+            allow(Genova::CodeManager::Git).to receive(:new).and_return(code_manager)
+            allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
+            allow(describe_services_response).to receive(:services).and_return([service])
+            allow(ecs_client).to receive(:describe_services).and_return(describe_services_response)
+            allow(service).to receive(:task_definition)
+            allow(describe_task_definition_response).to receive(:[]).with(:tags).and_return([{ key: 'genova.build' }])
+            allow(ecs_client).to receive(:describe_task_definition).and_return(describe_task_definition_response)
+
+            expect(client).to receive(:chat_postMessage) do |data|
+              note_block = data[:blocks].find { |block| block[:block_id] == 'deploy_note' }
+              expect(note_block[:element][:multiline]).to eq(true)
+            end
+
+            bot.ask_confirm_deploy(params, show_target: false)
+          end
+
+          it 'uses full-width section when note is present' do
+            allow(code_manager).to receive(:origin_last_commit).and_return('xxx')
+            allow(code_manager).to receive(:find_commit).and_return('yyy')
+            allow(Genova::CodeManager::Git).to receive(:new).and_return(code_manager)
+            allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
+            allow(describe_services_response).to receive(:services).and_return([service])
+            allow(ecs_client).to receive(:describe_services).and_return(describe_services_response)
+            allow(service).to receive(:task_definition)
+            allow(describe_task_definition_response).to receive(:[]).with(:tags).and_return([{ key: 'genova.build' }])
+            allow(ecs_client).to receive(:describe_task_definition).and_return(describe_task_definition_response)
+
+            expect(client).to receive(:chat_postMessage) do |data|
+              note_block = data[:blocks].find do |block|
+                block[:type] == 'section' && block.dig(:text, :text)&.include?('*Note:*')
+              end
+              expect(note_block[:fields]).to be_nil
+              expect(note_block.dig(:text, :text)).to include("line1\nline2")
+            end
+
+            bot.ask_confirm_deploy(params.merge(note: "line1\nline2"), show_target: false)
+          end
         end
 
         describe 'detect_auto_deploy' do

--- a/spec/models/deploy_job_spec.rb
+++ b/spec/models/deploy_job_spec.rb
@@ -1,4 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe DeployJob, type: :model do
+  describe 'note' do
+    let(:base_params) do
+      {
+        id: DeployJob.generate_id,
+        mode: DeployJob.mode.find_value(:manual),
+        type: DeployJob.type.find_value(:service),
+        account: Settings.github.account,
+        repository: 'repository',
+        cluster: 'cluster'
+      }
+    end
+
+    it 'truncates note before validation' do
+      deploy_job = DeployJob.create!(base_params.merge(note: 'a' * (DeployJob::NOTE_MAX_LENGTH + 1)))
+
+      expect(deploy_job.note.length).to eq(DeployJob::NOTE_MAX_LENGTH)
+    end
+
+    it 'keeps note within max length valid' do
+      deploy_job = DeployJob.new(base_params.merge(note: 'a' * DeployJob::NOTE_MAX_LENGTH))
+
+      expect(deploy_job).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
  ## 概要

  デプロイ実行時に任意のメモを付与できるようにしました。
  CLI、Slackコマンド、Slackインタラクティブ入力から `memo` を受け取り、DeployJobに保存してWeb UI上でも確認できるようにしています。

変更後Wiki
[CLI-deploy.md](https://github.com/user-attachments/files/27563120/CLI-deploy.md)

  ## 変更内容

  - `DeployJob` に `memo` フィールドを追加
  - CLIデプロイに `--memo` オプションを追加
  - Slack経由のデプロイで `memo` パラメータを受け渡しできるように変更
  - Slackのデプロイ確認画面に、未指定時は任意入力のMemo欄を表示
  - Slack確認画面で入力されたMemoをセッションに保存し、デプロイジョブ作成時に反映
  - DeployJob詳細画面にMemoを表示
  - MemoがURLの場合はWeb UI上でリンクとして表示
  - Slackコマンドパラメータのパースを `split('=', 2)` に変更し、値に `=` を含むケースに対応
  - Slackメンションからの入力で、テキストだけでなくリンク要素のURLもコマンド文として扱えるように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploy jobs can include an optional note (text or link); shown on deploy detail pages and available via CLI (--note) and Slack flows.
  * Slack confirmation UI supports multiline note input and renders provided notes inline or as external links.

* **Bug Fixes**
  * Improved Slack message parsing to assemble full statements from block elements and ignore unsupported elements.
  * Parameter parsing preserves values containing '='; deployment responses now send a plain "Deployment started." message.

* **Tests**
  * Added specs for note persistence, Slack parsing, block helpers, and request/interactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->