### PR TITLE
Ignore unsupported keys in container override

### DIFF
--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -1,46 +1,47 @@
 {
   "definitions": {
+    "docker_build": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "context": { "type": "string" },
+            "dockerfile": { "type": "string" },
+            "args": {
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "oneOf": [
+                    { "type": "number" },
+                    { "type": "string" },
+                    { "type": "boolean" }
+                  ]
+                }
+              }
+            },
+            "secret_args": {
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "oneOf": [
+                    { "type": "string" }
+                  ]
+                }
+              }
+            },
+            "target": { "type": "string" }
+          }
+        }
+      ]
+    },
     "containers": {
       "type": "array",
       "items": {
         "required": ["name", "build"],
         "properties": {
           "name": { "type": "string" },
-          "build": {
-            "oneOf": [
-              { "type": "string" },
-              {
-                "type": "object",
-                "properties": {
-                  "context": { "type": "string" },
-                  "dockerfile": { "type": "string" },
-                  "args": {
-                    "type": "object",
-                    "patternProperties": {
-                      ".+": {
-                        "oneOf": [
-                          { "type": "number" },
-                          { "type": "string" },
-                          { "type": "boolean" }
-                        ]
-                      }
-                    }
-                  },
-                  "secret_args": {
-                    "type": "object",
-                    "patternProperties": {
-                      ".+": {
-                        "oneOf": [
-                          { "type": "string" }
-                        ]
-                      }
-                    }
-                  },
-                  "target": { "type": "string" }
-                }
-              }
-            ]
-          }
+          "build": { "$ref": "#/definitions/docker_build" }
         }
       }
     },
@@ -75,6 +76,7 @@
       "items": {
         "type": "object",
         "required": ["name"],
+        "additionalProperties": false,
         "properties": {
           "name": { "type": "string" },
           "command": {
@@ -83,6 +85,7 @@
           },
           "environment": { "$ref": "#/definitions/container_override_environment" },
           "secrets": { "$ref": "#/definitions/container_override_secrets" },
+          "build": { "$ref": "#/definitions/docker_build" },
           "environment_from_files": {
             "type": "array",
             "items": { "type": "string" }

--- a/lib/autoloads/genova/config/validator/deploy_config.json
+++ b/lib/autoloads/genova/config/validator/deploy_config.json
@@ -5,6 +5,7 @@
         { "type": "string" },
         {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "context": { "type": "string" },
             "dockerfile": { "type": "string" },

--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -1,6 +1,8 @@
 module Genova
   module Ecs
     class Client
+      IGNORED_CONTAINER_OVERRIDE_KEYS = %i[environment_from_files secrets_from_files build].freeze
+
       def initialize(deploy_job, options, logger)
         @deploy_job = deploy_job
         @code_manager = CodeManager::Git.new(
@@ -184,7 +186,8 @@ module Genova
 
         config[:container_overrides] = Ecs::ContainerOverrideBuilder.build(
           container_overrides_config,
-          base_dir: deploy_config_base_dir
+          base_dir: deploy_config_base_dir,
+          logger: @logger
         )
       end
 
@@ -206,7 +209,7 @@ module Genova
       end
 
       def apply_container_override_to_task_overrides!(task_overrides, container_override)
-        override_container_definition = container_override.deep_dup.deep_symbolize_keys.except(:environment_from_files, :secrets_from_files)
+        override_container_definition = sanitize_container_override(container_override)
         container_definition = task_overrides[:container_definitions].find do |current_container_definition|
           current_container_definition[:name] == override_container_definition[:name]
         end
@@ -222,10 +225,14 @@ module Genova
 
       def runtime_container_overrides(container_overrides)
         normalized_overrides = Array(container_overrides).map do |container_override|
-          container_override.deep_dup.deep_symbolize_keys.except(:secrets, :secrets_from_files)
+          sanitize_container_override(container_override).except(:secrets)
         end
 
         normalized_overrides.reject { |container_override| container_override.except(:name).blank? }
+      end
+
+      def sanitize_container_override(container_override)
+        container_override.deep_dup.deep_symbolize_keys.except(*IGNORED_CONTAINER_OVERRIDE_KEYS)
       end
     end
   end

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -46,10 +46,13 @@ module Genova
         end
 
         def warn_and_remove_build_key!(container_override, container_identifier, logger)
-          return unless (container_override.keys & IGNORED_KEYS).include?(:build)
+          ignored_keys = container_override.keys & IGNORED_KEYS
+          return if ignored_keys.empty?
 
-          logger&.warn("Ignore 'build' key in container override '#{container_identifier}'.")
-          container_override.delete(:build)
+          ignored_keys.each do |ignored_key|
+            logger&.warn("Ignore '#{ignored_key}' key in container override '#{container_identifier}'.")
+            container_override.delete(ignored_key)
+          end
         end
 
         def validate_supported_keys!(container_override, container_identifier)

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -1,7 +1,8 @@
 module Genova
   module Ecs
     class ContainerOverrideBuilder
-      SUPPORTED_KEYS = %i[name command environment secrets environment_from_files secrets_from_files build].freeze
+      SUPPORTED_KEYS = %i[name command environment secrets environment_from_files secrets_from_files].freeze
+      IGNORED_KEYS = %i[build].freeze
 
       ENTRY_TYPES = {
         environment: {
@@ -45,14 +46,14 @@ module Genova
         end
 
         def warn_and_remove_build_key!(container_override, container_identifier, logger)
-          return unless container_override.key?(:build)
+          return unless (container_override.keys & IGNORED_KEYS).include?(:build)
 
           logger&.warn("Ignore 'build' key in container override '#{container_identifier}'.")
           container_override.delete(:build)
         end
 
         def validate_supported_keys!(container_override, container_identifier)
-          unsupported_keys = container_override.keys - (SUPPORTED_KEYS - [:build])
+          unsupported_keys = container_override.keys - SUPPORTED_KEYS
           return if unsupported_keys.empty?
 
           raise Exceptions::ValidationError,

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -1,6 +1,8 @@
 module Genova
   module Ecs
     class ContainerOverrideBuilder
+      SUPPORTED_KEYS = %i[name command environment secrets environment_from_files secrets_from_files build].freeze
+
       ENTRY_TYPES = {
         environment: {
           file_key: :environment_from_files,
@@ -17,27 +19,44 @@ module Genova
       }.freeze
 
       class << self
-        def build(container_overrides_config, base_dir:)
+        def build(container_overrides_config, base_dir:, logger: nil)
           return [] if container_overrides_config.blank?
           raise Exceptions::ValidationError, "'container_overrides' must be an array." unless container_overrides_config.is_a?(Array)
 
           container_overrides_config.map do |container_override_config|
-            build_container_override(container_override_config, base_dir)
+            build_container_override(container_override_config, base_dir, logger)
           end
         end
 
         private
 
-        def build_container_override(container_override_config, base_dir)
+        def build_container_override(container_override_config, base_dir, logger)
           raise Exceptions::ValidationError, "Each entry in 'container_overrides' must be a hash. [#{container_override_config.inspect}]" unless container_override_config.is_a?(Hash)
 
           container_override = container_override_config.deep_dup.deep_symbolize_keys
           container_identifier = container_override[:name] || '(unknown)'
+          warn_and_remove_build_key!(container_override, container_identifier, logger)
+          validate_supported_keys!(container_override, container_identifier)
           ENTRY_TYPES.each_key do |entry_type|
             assign_named_entries!(container_override, entry_type, base_dir, container_identifier)
           end
 
           container_override
+        end
+
+        def warn_and_remove_build_key!(container_override, container_identifier, logger)
+          return unless container_override.key?(:build)
+
+          logger&.warn("Ignore 'build' key in container override '#{container_identifier}'.")
+          container_override.delete(:build)
+        end
+
+        def validate_supported_keys!(container_override, container_identifier)
+          unsupported_keys = container_override.keys - (SUPPORTED_KEYS - [:build])
+          return if unsupported_keys.empty?
+
+          raise Exceptions::ValidationError,
+                "Unsupported keys in container override '#{container_identifier}'. [#{unsupported_keys.sort.join(', ')}]"
         end
 
         def assign_named_entries!(container_override, entry_type, base_dir, container_identifier)

--- a/lib/autoloads/genova/ecs/container_override_builder.rb
+++ b/lib/autoloads/genova/ecs/container_override_builder.rb
@@ -25,13 +25,13 @@ module Genova
           raise Exceptions::ValidationError, "'container_overrides' must be an array." unless container_overrides_config.is_a?(Array)
 
           container_overrides_config.map do |container_override_config|
-            build_container_override(container_override_config, base_dir, logger)
+            build_container_override(container_override_config, base_dir:, logger:)
           end
         end
 
         private
 
-        def build_container_override(container_override_config, base_dir, logger)
+        def build_container_override(container_override_config, base_dir:, logger:)
           raise Exceptions::ValidationError, "Each entry in 'container_overrides' must be a hash. [#{container_override_config.inspect}]" unless container_override_config.is_a?(Hash)
 
           container_override = container_override_config.deep_dup.deep_symbolize_keys

--- a/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
+++ b/lib/autoloads/genova/ecs/deployer/scheduled_task/target.rb
@@ -46,7 +46,12 @@ module Genova
             private
 
             def override_container(container_override_config)
-              container_override = container_override_config.deep_dup.deep_symbolize_keys.except(:environment_from_files, :secrets_from_files, :secrets)
+              container_override = container_override_config.deep_dup.deep_symbolize_keys.except(
+                :environment_from_files,
+                :secrets_from_files,
+                :secrets,
+                :build
+              )
               environment_overrides = Ecs::NamedEntries.normalize(
                 container_override[:environment],
                 value_key: :value,

--- a/spec/lib/autoloads/genova/config/deploy_config_spec.rb
+++ b/spec/lib/autoloads/genova/config/deploy_config_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Genova
   module Config
     describe DeployConfig do
-      describe 'validate!' do
+      describe '.new' do
         let(:base_config) do
           {
             clusters: [

--- a/spec/lib/autoloads/genova/config/deploy_config_spec.rb
+++ b/spec/lib/autoloads/genova/config/deploy_config_spec.rb
@@ -3,6 +3,63 @@ require 'rails_helper'
 module Genova
   module Config
     describe DeployConfig do
+      describe 'validate!' do
+        let(:base_config) do
+          {
+            clusters: [
+              {
+                name: 'production',
+                services: {
+                  app: {
+                    path: './deploy/production.yml',
+                    containers: [
+                      {
+                        name: 'app',
+                        build: {
+                          context: '..'
+                        }
+                      }
+                    ],
+                    container_overrides: [
+                      container_override
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        end
+
+        context 'when build is defined in container_overrides' do
+          let(:container_override) do
+            {
+              name: 'app',
+              build: {
+                context: '..'
+              }
+            }
+          end
+
+          it 'accepts the config' do
+            expect { described_class.new(base_config) }.not_to raise_error
+          end
+        end
+
+        context 'when an unsupported key is defined in container_overrides' do
+          let(:container_override) do
+            {
+              name: 'app',
+              environment_from_file: [
+                './deploy/env/app.env'
+              ]
+            }
+          end
+
+          it 'raises validation error' do
+            expect { described_class.new(base_config) }.to raise_error(Exceptions::ValidationError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/autoloads/genova/config/deploy_config_spec.rb
+++ b/spec/lib/autoloads/genova/config/deploy_config_spec.rb
@@ -45,6 +45,21 @@ module Genova
           end
         end
 
+        context 'when an unsupported key is defined in build' do
+          let(:container_override) do
+            {
+              name: 'app',
+              build: {
+                contex: '..'
+              }
+            }
+          end
+
+          it 'raises validation error' do
+            expect { described_class.new(base_config) }.to raise_error(Exceptions::ValidationError)
+          end
+        end
+
         context 'when an unsupported key is defined in container_overrides' do
           let(:container_override) do
             {

--- a/spec/lib/autoloads/genova/ecs/client_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/client_spec.rb
@@ -457,6 +457,75 @@ module Genova
             expect { client.deploy_scheduled_task }.to_not raise_error
           end
         end
+
+        describe 'runtime_container_overrides' do
+          it 'ignores build in container_overrides' do
+            overrides = client.send(
+              :runtime_container_overrides,
+              [
+                {
+                  name: 'web',
+                  build: {
+                    context: '..'
+                  },
+                  command: %w[bundle exec puma],
+                  environment: [
+                    { name: 'RAILS_ENV', value: 'production' }
+                  ]
+                }
+              ]
+            )
+
+            expect(overrides).to eq(
+              [
+                {
+                  name: 'web',
+                  command: %w[bundle exec puma],
+                  environment: [
+                    { name: 'RAILS_ENV', value: 'production' }
+                  ]
+                }
+              ]
+            )
+          end
+        end
+
+        describe 'apply_container_override_to_task_overrides!' do
+          it 'ignores build when merging container_overrides into task_overrides' do
+            task_overrides = {
+              container_definitions: [
+                {
+                  name: 'web',
+                  image: 'example/web:latest'
+                }
+              ]
+            }
+
+            client.send(
+              :apply_container_override_to_task_overrides!,
+              task_overrides,
+              {
+                name: 'web',
+                build: {
+                  context: '..'
+                },
+                command: %w[bundle exec puma]
+              }
+            )
+
+            expect(task_overrides).to eq(
+              {
+                container_definitions: [
+                  {
+                    name: 'web',
+                    image: 'example/web:latest',
+                    command: %w[bundle exec puma]
+                  }
+                ]
+              }
+            )
+          end
+        end
       end
     end
   end

--- a/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/container_override_builder_spec.rb
@@ -5,6 +5,7 @@ module Genova
     describe ContainerOverrideBuilder do
       describe 'build' do
         let(:base_dir) { '/repo/config' }
+        let(:logger) { instance_double(Logger, warn: nil) }
 
         it 'loads environment from files and allows inline environment to override it' do
           env_file_path = '/repo/config/app.env'
@@ -199,6 +200,53 @@ module Genova
               base_dir:
             )
           end.to raise_error(Exceptions::ValidationError, 'Secrets file does not exist. [/repo/config/missing-secrets.env]')
+        end
+
+        it 'warns and ignores build key' do
+          expect(logger).to receive(:warn).with(
+            "Ignore 'build' key in container override 'app'."
+          )
+
+          container_overrides = described_class.build(
+            [
+              {
+                name: 'app',
+                command: %w[bundle exec rake],
+                build: {
+                  context: '..'
+                }
+              }
+            ],
+            base_dir:,
+            logger:
+          )
+
+          expect(container_overrides).to eq(
+            [
+              {
+                name: 'app',
+                command: %w[bundle exec rake]
+              }
+            ]
+          )
+        end
+
+        it 'raises error when unsupported keys are defined' do
+          expect do
+            described_class.build(
+              [
+                {
+                  name: 'app',
+                  unsupported: 'value'
+                }
+              ],
+              base_dir:,
+              logger:
+            )
+          end.to raise_error(
+            Exceptions::ValidationError,
+            "Unsupported keys in container override 'app'. [unsupported]"
+          )
         end
       end
     end

--- a/spec/lib/autoloads/genova/ecs/deployer/scheduled_task/target_spec.rb
+++ b/spec/lib/autoloads/genova/ecs/deployer/scheduled_task/target_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+module Genova
+  module Ecs
+    module Deployer
+      module ScheduledTask
+        describe Target do
+          describe 'override_container' do
+            it 'ignores build in container_overrides' do
+              override = described_class.send(
+                :override_container,
+                {
+                  name: 'web',
+                  build: {
+                    context: '..'
+                  },
+                  command: %w[bundle exec rake],
+                  environment: [
+                    { 'RAILS_ENV' => 'production' }
+                  ]
+                }
+              )
+
+              expect(override).to eq(
+                {
+                  name: 'web',
+                  command: %w[bundle exec rake],
+                  environment: [
+                    { name: 'RAILS_ENV', value: 'production' }
+                  ]
+                }
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
container_overrides に build キーが含まれている場合でも、デプロイ時に ECS API へ渡さず警告付きで無視するように修正しました。あわせて、build 以外の未対応キーは従来どおり fail-fast になるようバリデーションを強化しています。

## 背景
PR #453 の変更後、container_overrides が task_overrides.container_definitions や runtime override にマージされる経路で build がそのまま ECS API に流れ、register_task_definition で unexpected value at params[:container_definitions][0][:build] が発生していました。

## 変更内容
container_overrides の読み込み時に build を検出した場合、logger.warn を出して削除する処理を追加
container_overrides から ECS 向けデータへ変換する経路でも build を除外するよう修正task_overrides.container_definitions へのマージ
run_task / scheduled_task の runtime container override 生成

container_overrides の JSON Schema を厳格化additionalProperties: false を追加
build だけは互換性維持のため schema 上は許可
environment_from_file のような typo や未知キーは validation error にする

build 定義を docker_build として共通化し、containers[].build / container_overrides[].build の両方で再利用

## 期待される挙動
container_overrides.build があっても deploy 設定としては受理される
実際のデプロイ処理では build は警告付きで無視され、ECS API には渡らない
build 以外の未対応キーが含まれている場合は validation error で早期に検知できる
entry_point や linux_parameters など、既存で container_overrides 経由で task definition に流していた ECS 対応キーは引き続き利用可能

## テスト
ContainerOverrideBuilderbuild を警告付きで無視すること
未対応キーで ValidationError になること

DeployConfigcontainer_overrides.build は validate を通ること
未対応キーは schema validation で落ちること

Ecs::Clientbuild が task definition / runtime override に混入しないこと

ScheduledTask::Targetbuild が scheduled task の runtime override に混入しないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container override configurations can now include a reusable build section (string or object form).
* **Bug Fixes**
  * Build details are now consistently ignored when generating/applying runtime container overrides, while supported fields (like command and environment) are preserved.
* **Validation / Behavior Changes**
  * Override schemas were tightened to reject unknown fields, and unsupported keys now fail validation with clearer errors.
  * When `build` is present in overrides, it is explicitly ignored with a warning.
* **Tests**
  * Added/expanded specs covering deploy config validation and container override normalization/merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->