### PR TITLE
Ignore unsupported keys in container override

### DIFF
--- a/lib/autoloads/genova/ecs/client.rb
+++ b/lib/autoloads/genova/ecs/client.rb
@@ -185,7 +185,10 @@ module Genova
         config[:container_overrides] = Ecs::ContainerOverrideBuilder.build(
           container_overrides_config,
           base_dir: deploy_config_base_dir
-        )
+        ).map do |container_override|
+            @logger.warn(%("build" in container_overrides is ignored for "#{container_override[:name]}". Use top-level "containers" for image build settings.)) if container_override.include?(:build)
+          container_override.except(:build)
+        end
       end
 
       def deploy_config_base_dir


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container override settings are now cleaned before being applied, preventing unsupported build-related fields from being passed through.
  * A warning is logged when a build-related field is detected and removed, helping surface unexpected configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->