### PR TITLE
Support alias (monorepo) in workflow deploy steps

### DIFF
--- a/lib/autoloads/genova/deploy/step/runner.rb
+++ b/lib/autoloads/genova/deploy/step/runner.rb
@@ -7,6 +7,9 @@ module Genova
             steps.each.with_index(1) do |step, i|
               callback.start_step(index: i)
 
+              repository_name = options[:repository] || step[:repository]
+              repository_settings = Genova::Config::SettingsHelper.find_repository(repository_name)
+
               step[:resources].each do |resource|
                 service, run_task, scheduled_task = extract_resources(step[:type], resource)
                 scheduled_task_rule, scheduled_task_target = extract_scheduled_task(scheduled_task) if scheduled_task.present?
@@ -20,7 +23,8 @@ module Genova
                   slack_user_name: options[:slack_user_name],
                   slack_timestamp: options[:slack_timestamp],
                   account: Settings.github.account,
-                  repository: options[:repository] || step[:repository],
+                  repository: repository_settings.present? ? repository_settings[:name] : repository_name,
+                  alias: repository_settings.present? ? repository_settings[:alias] : nil,
                   branch: options[:branch] || step[:branch],
                   cluster: step[:cluster],
                   service:,

--- a/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
+++ b/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
@@ -67,25 +67,25 @@ module Genova
                   type:,
                   resources:,
                   cluster: 'cluster',
-                  repository: 'reshine-profile',
+                  repository: 'repository-alias',
                   branch: 'branch'
                 }
               ]
             end
 
             before do
-              allow(Genova::Config::SettingsHelper).to receive(:find_repository).with('reshine-profile').and_return(
-                name: 'reshine',
-                base_path: './profile',
-                alias: 'reshine-profile'
+              allow(Genova::Config::SettingsHelper).to receive(:find_repository).with('repository-alias').and_return(
+                name: 'repository',
+                base_path: './base_path',
+                alias: 'repository-alias'
               )
             end
 
             it 'resolves real repository name and stores alias in deploy job' do
               Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym)
 
-              expect(DeployJob.last.repository).to eq('reshine')
-              expect(DeployJob.last.alias).to eq('reshine-profile')
+              expect(DeployJob.last.repository).to eq('repository')
+              expect(DeployJob.last.alias).to eq('repository-alias')
             end
           end
 

--- a/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
+++ b/spec/lib/autoloads/genova/deploy/step/runner_spec.rb
@@ -58,6 +58,37 @@ module Genova
             end
           end
 
+          context 'when repository has alias' do
+            let(:type) { 'service' }
+            let(:resources) { ['resource'] }
+            let(:steps) do
+              [
+                {
+                  type:,
+                  resources:,
+                  cluster: 'cluster',
+                  repository: 'reshine-profile',
+                  branch: 'branch'
+                }
+              ]
+            end
+
+            before do
+              allow(Genova::Config::SettingsHelper).to receive(:find_repository).with('reshine-profile').and_return(
+                name: 'reshine',
+                base_path: './profile',
+                alias: 'reshine-profile'
+              )
+            end
+
+            it 'resolves real repository name and stores alias in deploy job' do
+              Runner.call(steps, StdoutHook.new, mode: DeployJob.mode.find_value(:manual).to_sym)
+
+              expect(DeployJob.last.repository).to eq('reshine')
+              expect(DeployJob.last.alias).to eq('reshine-profile')
+            end
+          end
+
           context 'when update run task' do
             let(:type) { 'run_task' }
             let(:resources) { ['resource'] }


### PR DESCRIPTION
Resolve each workflow step's repository via SettingsHelper.find_repository so an alias can be given as the step's repository. The real repository name and alias are stored separately on the DeployJob, letting workflow steps target a monorepo subdirectory (base_path), matching the CLI/Slack deploy flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment jobs now use the configured repository name and alias when available.
  - When no configuration is found, deployments retain the selected repository name without an alias.

- **Tests**
  - Added coverage to verify repository alias handling during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->