### PR TITLE
Add Note (optional) field to Slack workflow deploy

### DIFF
--- a/app/workers/slack/workflow_deploy_worker.rb
+++ b/app/workers/slack/workflow_deploy_worker.rb
@@ -15,7 +15,8 @@ module Slack
         mode: DeployJob.mode.find_value(:slack),
         slack_user_id: params[:user],
         slack_user_name: params[:user_name],
-        slack_timestamp: id
+        slack_timestamp: id,
+        note: params[:note]
       )
     rescue => e
       params.present? ? send_error(e, id, params[:user]) : send_error(e, id)

--- a/lib/autoloads/genova/slack/interactive/bot.rb
+++ b/lib/autoloads/genova/slack/interactive/bot.rb
@@ -163,6 +163,8 @@ module Genova
             )
           end
 
+          blocks << BlockKit::Helper.plain_text_input('submit_deploy_note', 'Note (optional)', placeholder: 'Input any text', block_id: 'deploy_note', multiline: true)
+
           blocks << BlockKit::Helper.actions([
                                                BlockKit::Helper.primary_button('Deploy', 'deploy', 'selected_workflow_deploy'),
                                                BlockKit::Helper.button('Cancel', 'cancel', 'submit_cancel')

--- a/lib/autoloads/genova/slack/request_handler.rb
+++ b/lib/autoloads/genova/slack/request_handler.rb
@@ -182,6 +182,9 @@ module Genova
           permission = Interactive::Permission.new(@payload[:user][:id])
           raise Genova::Exceptions::SlackPermissionDeniedError, "User #{@payload[:user][:id]} does not have execute permission." unless permission.allow_workflow?(@session_store.params[:workflow])
 
+          note = @payload.dig(:state, :values, :deploy_note, :submit_deploy_note, :value)
+          @session_store.merge({ note: }) if note.present?
+
           ::Slack::WorkflowDeployWorker.perform_async(@thread_ts)
 
           show_message('Workflow deployment started.')


### PR DESCRIPTION
Render the Note input on the workflow deploy confirmation, extract it on submit, and pass it through WorkflowDeployWorker so every step's DeployJob records the note, matching the regular Slack deploy flow.