### PR TITLE
Reduce Docker disk usage: prune build cache and shorten retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 /public/assets/*
 /.ssh
 
+# Claude Code
+/.claude
+
 # Application files
 *.swp
 !.keep

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,7 @@ logger:
 timezone: UTC
 
 docker:
-  retention_days: 20
+  retention_days: 14
   # build:
   #   # Memory usage allowed at build time. For example `1024m`.
   #   # This option maps to `docker build --memory`.

--- a/lib/autoloads/genova/docker/image_cleaner.rb
+++ b/lib/autoloads/genova/docker/image_cleaner.rb
@@ -25,9 +25,21 @@ module Genova
           end
 
           logger.info('Deleted unused images.')
+
+          prune_build_cache(logger)
         end
 
         private
+
+        def prune_build_cache(logger)
+          retention_hours = (RETENTION_SEC / (60 * 60)).to_i
+          command = "docker builder prune --force --filter until=#{retention_hours}h"
+
+          Genova::Command::Executor.call(command, logger)
+          logger.info('Pruned build cache.')
+        rescue => e
+          logger.warn("Failed to prune build cache. #{e.message}")
+        end
 
         def using_images
           images = []

--- a/spec/lib/autoloads/genova/docker/image_cleaner_spec.rb
+++ b/spec/lib/autoloads/genova/docker/image_cleaner_spec.rb
@@ -14,6 +14,7 @@ module Genova
         allow(image).to receive(:id).and_return('id')
         allow(image).to receive(:remove)
         allow(::Docker::Image).to receive(:all).and_return([image])
+        allow(Genova::Command::Executor).to receive(:call)
       end
 
       let(:image) { double(::Docker::Image) }
@@ -44,6 +45,23 @@ module Genova
           it 'should return execute result' do
             expect { Genova::Docker::ImageCleaner.call }.not_to raise_error
             expect(image).to have_received(:remove).once
+          end
+        end
+
+        context 'build cache' do
+          it 'prunes build cache older than the retention period' do
+            Genova::Docker::ImageCleaner.call
+
+            expect(Genova::Command::Executor).to have_received(:call).with(
+              a_string_matching(/\Adocker builder prune --force --filter until=\d+h\z/),
+              anything
+            )
+          end
+
+          it 'does not abort when pruning fails' do
+            allow(Genova::Command::Executor).to receive(:call).and_raise(StandardError, 'boom')
+
+            expect { Genova::Docker::ImageCleaner.call }.not_to raise_error
           end
         end
       end


### PR DESCRIPTION
Addresses disk exhaustion caused by Docker artifacts (build cache and images)
accumulating from genova's builds.
