### PR TITLE
Stream deploy job logs and status live via SSE

### DIFF
--- a/app/controllers/deploy_job_streams_controller.rb
+++ b/app/controllers/deploy_job_streams_controller.rb
@@ -1,18 +1,9 @@
-# Streams a deploy job's logs and status to the console via Server-Sent Events
-# so the page tails output like GitHub Actions. Kept separate from
-# DeployJobsController because ActionController::Live changes response handling
-# for every action in the controller it is included in.
 class DeployJobStreamsController < ActionController::Base
   include ActionController::Live
 
   POLL_INTERVAL = 1
   HEARTBEAT_INTERVAL = 20
-  # Cap how long a single connection holds a Puma thread. When the deploy is
-  # still running past this, the stream closes and the browser's EventSource
-  # reconnects, resuming from Last-Event-ID. This bounds thread occupancy so a
-  # long-running or stuck deploy (or an abandoned open tab) cannot pin a thread
-  # indefinitely.
-  MAX_STREAM_SECONDS = 600
+  MAX_STREAM_SECONDS = 900
   FINISHED_STATUSES = %w[success failure cancel].freeze
 
   def show
@@ -21,12 +12,8 @@ class DeployJobStreamsController < ActionController::Base
 
     response.headers['Content-Type'] = 'text/event-stream'
     response.headers['Cache-Control'] = 'no-cache'
-    # Tell nginx not to buffer this response so events flush immediately,
-    # without requiring an nginx config change.
     response.headers['X-Accel-Buffering'] = 'no'
 
-    # Resume from the last event the browser received (SSE reconnect) or from
-    # the count of log lines the page already rendered server-side.
     sent = (request.headers['Last-Event-ID'] || params[:offset]).to_i
     last_status = nil
     idle = 0
@@ -40,6 +27,7 @@ class DeployJobStreamsController < ActionController::Base
         logs[sent..].each_with_index do |line, i|
           write_event(sent + i + 1, { type: 'log', line: })
         end
+
         sent = logs.length
         idle = 0
       end
@@ -51,9 +39,9 @@ class DeployJobStreamsController < ActionController::Base
       end
 
       break if FINISHED_STATUSES.include?(deploy_job.status)
-      break if Time.now >= deadline
 
       idle += POLL_INTERVAL
+
       if idle >= HEARTBEAT_INTERVAL
         response.stream.write(": heartbeat\n\n")
         idle = 0
@@ -62,7 +50,6 @@ class DeployJobStreamsController < ActionController::Base
       sleep POLL_INTERVAL
     end
   rescue ActionController::Live::ClientDisconnected, IOError
-    # Browser closed the connection; nothing to clean up beyond the ensure.
   ensure
     response.stream.close
   end

--- a/app/controllers/deploy_job_streams_controller.rb
+++ b/app/controllers/deploy_job_streams_controller.rb
@@ -1,0 +1,76 @@
+# Streams a deploy job's logs and status to the console via Server-Sent Events
+# so the page tails output like GitHub Actions. Kept separate from
+# DeployJobsController because ActionController::Live changes response handling
+# for every action in the controller it is included in.
+class DeployJobStreamsController < ActionController::Base
+  include ActionController::Live
+
+  POLL_INTERVAL = 1
+  HEARTBEAT_INTERVAL = 20
+  # Cap how long a single connection holds a Puma thread. When the deploy is
+  # still running past this, the stream closes and the browser's EventSource
+  # reconnects, resuming from Last-Event-ID. This bounds thread occupancy so a
+  # long-running or stuck deploy (or an abandoned open tab) cannot pin a thread
+  # indefinitely.
+  MAX_STREAM_SECONDS = 600
+  FINISHED_STATUSES = %w[success failure cancel].freeze
+
+  def show
+    deploy_job = DeployJob.find(params[:id])
+    return head(:not_found) if deploy_job.nil?
+
+    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers['Cache-Control'] = 'no-cache'
+    # Tell nginx not to buffer this response so events flush immediately,
+    # without requiring an nginx config change.
+    response.headers['X-Accel-Buffering'] = 'no'
+
+    # Resume from the last event the browser received (SSE reconnect) or from
+    # the count of log lines the page already rendered server-side.
+    sent = (request.headers['Last-Event-ID'] || params[:offset]).to_i
+    last_status = nil
+    idle = 0
+    deadline = Time.now + MAX_STREAM_SECONDS
+
+    loop do
+      deploy_job.reload
+      logs = deploy_job.logs || []
+
+      if logs.length > sent
+        logs[sent..].each_with_index do |line, i|
+          write_event(sent + i + 1, { type: 'log', line: })
+        end
+        sent = logs.length
+        idle = 0
+      end
+
+      if deploy_job.status != last_status
+        last_status = deploy_job.status
+        write_event(nil, { type: 'status', status: deploy_job.status, finished: FINISHED_STATUSES.include?(deploy_job.status) })
+        idle = 0
+      end
+
+      break if FINISHED_STATUSES.include?(deploy_job.status)
+      break if Time.now >= deadline
+
+      idle += POLL_INTERVAL
+      if idle >= HEARTBEAT_INTERVAL
+        response.stream.write(": heartbeat\n\n")
+        idle = 0
+      end
+
+      sleep POLL_INTERVAL
+    end
+  rescue ActionController::Live::ClientDisconnected, IOError
+    # Browser closed the connection; nothing to clean up beyond the ensure.
+  ensure
+    response.stream.close
+  end
+
+  private
+
+  def write_event(id, payload)
+    response.stream.write("id: #{id}\n") if id
+    response.stream.write("data: #{payload.to_json}\n\n")
+  end
+end

--- a/app/javascript/entrypoints/deploy_job.js
+++ b/app/javascript/entrypoints/deploy_job.js
@@ -1,0 +1,66 @@
+// Live-updates the deploy job show page (logs + status) via Server-Sent Events
+// while a deployment is in progress, so the console tails output like GitHub
+// Actions. Uses the native EventSource API (no extra dependency).
+const FINISHED_STATUSES = ['success', 'failure', 'cancel'];
+
+const STATUS_ICONS = {
+  success: 'fa fa-check-circle',
+  initial: 'fa fa-spinner fa-spin',
+  provisioning: 'fa fa-spinner fa-spin',
+  deploying: 'fa fa-spinner fa-spin',
+  reserved_cancel: 'fa fa-spinner fa-spin',
+  failure: 'fa fa-exclamation-triangle',
+  cancel: 'fa fa-times-circle',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('[data-deploy-job-id]');
+  if (!root) return;
+
+  const deployJobId = root.dataset.deployJobId;
+  if (FINISHED_STATUSES.includes(root.dataset.status)) return;
+
+  const logsEl = document.querySelector('.logs');
+  const statusEl = document.getElementById('deploy-status');
+
+  const appendLog = (line) => {
+    if (!logsEl) return;
+    const placeholder = logsEl.querySelector('[data-logs-placeholder]');
+    if (placeholder) placeholder.remove();
+
+    // Only auto-scroll when the user is already near the bottom, so scrolling
+    // up to read earlier output during streaming is not interrupted.
+    const nearBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 100;
+
+    const pre = document.createElement('pre');
+    pre.textContent = line;
+    logsEl.appendChild(pre);
+
+    if (nearBottom) window.scrollTo(0, document.body.scrollHeight);
+  };
+
+  const updateStatus = (status) => {
+    if (!statusEl) return;
+    statusEl.innerHTML = `<i class="${STATUS_ICONS[status] || ''}"></i> ${status}`;
+  };
+
+  // The page already rendered the existing log lines server-side; resume from
+  // there so we only append new ones.
+  const offset = logsEl ? logsEl.querySelectorAll('pre').length : 0;
+  const source = new EventSource(`/deploy_jobs/${deployJobId}/stream?offset=${offset}`);
+
+  source.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.type === 'log') {
+      appendLog(data.line);
+    } else if (data.type === 'status') {
+      updateStatus(data.status);
+      if (data.finished) {
+        source.close();
+        // Reload once to render server-side final metadata (task ARNs,
+        // execution time, git tag) that is not streamed incrementally.
+        setTimeout(() => window.location.reload(), 800);
+      }
+    }
+  };
+});

--- a/app/javascript/entrypoints/deploy_job.js
+++ b/app/javascript/entrypoints/deploy_job.js
@@ -1,6 +1,3 @@
-// Live-updates the deploy job show page (logs + status) via Server-Sent Events
-// while a deployment is in progress, so the console tails output like GitHub
-// Actions. Uses the native EventSource API (no extra dependency).
 const FINISHED_STATUSES = ['success', 'failure', 'cancel'];
 
 const STATUS_ICONS = {

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -67,7 +67,7 @@
       </div>
       <div class="columns">
         <dt class="column is-2">Cluster</dt>
-        <dd class="column is-4"><%= @deploy_job.cluster %></dd>
+        <dd class="column is-4"><%= @deploy_job.cluster %></dd`>
         <% if @deploy_job.service.present? %>
           <dt class="column is-2">Service</dt>
           <dd class="column is-4"><%= @deploy_job.service %></dd>

--- a/app/views/deploy_jobs/show.html.erb
+++ b/app/views/deploy_jobs/show.html.erb
@@ -3,20 +3,22 @@
 
   <% if @deploy_job.present? %>
     <% github_client = Genova::Github::Client.new(@deploy_job.repository) %>
-    <dl class="meta">
+    <dl class="meta" data-deploy-job-id="<%= @deploy_job.id %>" data-status="<%= @deploy_job.status %>">
       <div class="columns">
         <dt class="column is-2">Status</dt>
         <dd class="column is-4">
-          <% if @deploy_job.status == 'success' %>
-            <i class="fa fa-check-circle"></i>
-          <% elsif ['initial', 'provisioning', 'deploying', 'reserved_cancel'].include?(@deploy_job.status) %>
-            <i class="fa fa-spinner fa-spin"></i>
-          <% elsif @deploy_job.status == 'failure' %>
-            <i class="fa fa-exclamation-triangle"></i>
-          <% elsif @deploy_job.status == 'cancel' %>
-            <i class="fa fa-times-circle"></i>
-          <% end %>
-          <%= @deploy_job.status %>
+          <span id="deploy-status">
+            <% if @deploy_job.status == 'success' %>
+              <i class="fa fa-check-circle"></i>
+            <% elsif ['initial', 'provisioning', 'deploying', 'reserved_cancel'].include?(@deploy_job.status) %>
+              <i class="fa fa-spinner fa-spin"></i>
+            <% elsif @deploy_job.status == 'failure' %>
+              <i class="fa fa-exclamation-triangle"></i>
+            <% elsif @deploy_job.status == 'cancel' %>
+              <i class="fa fa-times-circle"></i>
+            <% end %>
+            <%= @deploy_job.status %>
+          </span>
         </dd>
         <dt class="column is-2">Account</dt>
         <dd class="column is-4"><%= @deploy_job.account %></dd>
@@ -65,7 +67,7 @@
       </div>
       <div class="columns">
         <dt class="column is-2">Cluster</dt>
-        <dd class="column is-4"><%= @deploy_job.cluster %></dd`>
+        <dd class="column is-4"><%= @deploy_job.cluster %></dd>
         <% if @deploy_job.service.present? %>
           <dt class="column is-2">Service</dt>
           <dd class="column is-4"><%= @deploy_job.service %></dd>
@@ -159,15 +161,21 @@
           <span>Download</span>
         <% end %>
       </div>
-      <div class="logs">
+    <% end %>
+    <div class="logs">
+      <% if @deploy_job.logs.present? %>
         <% @deploy_job.logs.each do |log| %>
           <pre><%= log %></pre>
         <% end %>
-      </div>
-    <% else %>
-      <p>Log does not exist.</p>
-    <% end %>
+      <% else %>
+        <p data-logs-placeholder>Log does not exist.</p>
+      <% end %>
+    </div>
   <% else %>
    <p>No data found.</p>
   <% end %>
 </div>
+
+<% if @deploy_job.present? %>
+  <%= vite_javascript_tag 'deploy_job' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :deploy_jobs, only: %i[index show] do
     get :download, on: :member
   end
+  get 'deploy_jobs/:id/stream', to: 'deploy_job_streams#show', as: :deploy_job_stream
 
   get 'workflows', controller: :workflows, action: :index
   get 'latest_deployments', controller: :latest_deployments, action: :index

--- a/spec/requests/deploy_job_streams_spec.rb
+++ b/spec/requests/deploy_job_streams_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'DeployJobStreams', type: :request do
+  before { DeployJob.collection.drop }
+
+  describe 'GET /deploy_jobs/:id/stream' do
+    it 'streams existing logs and a finished status for a completed job as SSE' do
+      deploy_job = DeployJob.create!(
+        id: DeployJob.generate_id,
+        mode: DeployJob.mode.find_value(:manual),
+        type: DeployJob.type.find_value(:service),
+        account: 'account',
+        repository: 'repository',
+        cluster: 'cluster',
+        status: 'success',
+        logs: ['line 1', 'line 2']
+      )
+
+      get "/deploy_jobs/#{deploy_job.id}/stream"
+
+      expect(response.media_type).to eq('text/event-stream')
+      expect(response.headers['X-Accel-Buffering']).to eq('no')
+      expect(response.body).to include('"type":"log"', 'line 1', 'line 2')
+      expect(response.body).to include('"type":"status"', '"status":"success"', '"finished":true')
+    end
+
+    it 'skips log lines already rendered when an offset is given' do
+      deploy_job = DeployJob.create!(
+        id: DeployJob.generate_id,
+        mode: DeployJob.mode.find_value(:manual),
+        type: DeployJob.type.find_value(:service),
+        account: 'account',
+        repository: 'repository',
+        cluster: 'cluster',
+        status: 'success',
+        logs: ['line 1', 'line 2']
+      )
+
+      get "/deploy_jobs/#{deploy_job.id}/stream", params: { offset: 1 }
+
+      expect(response.body).not_to include('line 1')
+      expect(response.body).to include('line 2')
+    end
+
+    it 'returns 404 for an unknown job' do
+      get '/deploy_jobs/unknown/stream'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
On the deployment details page (`/deploy_jobs/:id`), logs and status will now update in real-time, similar to GitHub Actions. Previously, progress updates required a manual page reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live deployment log streaming for in-progress jobs.
  - Deployment status updates now appear automatically as jobs progress.
  - Logs resume from the last received position and continue updating with automatic scrolling.
  - Completed deployments close the live stream and refresh to display final details.
  - Added periodic connection keep-alives and graceful handling of disconnected sessions.

- **Bug Fixes**
  - Improved deployment log display when no logs are currently available.
  - Corrected cluster value rendering on deployment pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->